### PR TITLE
Feature/sequential option

### DIFF
--- a/src/covid_model_seiir_pipeline/core/versioner.py
+++ b/src/covid_model_seiir_pipeline/core/versioner.py
@@ -11,7 +11,7 @@ BASE_DIR = Path('/ihme')
 
 # Dependency/input directories
 INPUT_DIR = BASE_DIR / 'covid-19/seir-inputs'
-COVARIATE_DIR = BASE_DIR / 'covid-19/seir-outputs/test-seir-covariates'
+COVARIATE_DIR = BASE_DIR / 'covid-19/seir-covariates'
 
 # Output directory
 OUTPUT_DIR = BASE_DIR / 'covid-19/seir-pipeline-outputs'
@@ -20,7 +20,7 @@ OUTPUT_DIR = BASE_DIR / 'covid-19/seir-pipeline-outputs'
 METADATA_DIR = OUTPUT_DIR / 'metadata-inputs'
 REGRESSION_OUTPUT = OUTPUT_DIR / 'regression'
 FORECAST_OUTPUT = OUTPUT_DIR / 'forecast'
-COVARIATE_CACHE = BASE_DIR / 'covid-19/seir-outputs/test-seir-covariate-cache'
+COVARIATE_CACHE = OUTPUT_DIR / 'covariate'
 
 # File pattern for storing infectionator outputs
 INFECTION_FILE_PATTERN = 'draw{draw_id:04}_prepped_deaths_and_cases_all_age.csv'

--- a/src/covid_model_seiir_pipeline/executor/beta_regression.py
+++ b/src/covid_model_seiir_pipeline/executor/beta_regression.py
@@ -107,7 +107,7 @@ def run_beta_regression(draw_id: int, regression_version: str):
         mr_data=mr_data,
         path=directories.get_draw_coefficient_file(draw_id),
         df_cov_coef=fixed_coefficients,
-        add_intercept=False,
+        sequential=settings.sequential
     )
     # -------------------- POST PROCESSING AND SAVING ------------------------ #
     # Get the fitted values of beta from the regression model and append on


### PR DESCRIPTION
Add the option to run sequential regression based on a `sequential` RegressionVersion setting that is `False` by default. Passes this option to an updated `ModelRunner.fit_beta_regression_prod()` method in the covid-model-seiir repository.