### PR TITLE
Incorporating beta_shift updates

### DIFF
--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -21,10 +21,12 @@ class ScenarioSpecification:
     """Forecasting specification for a scenario."""
     ALLOWED_ALGORITHMS = ('RK45',)
     NO_BETA_SCALING = -1
+    NO_AVG_OVER = -1
 
     name: str = field(default='dummy_scenario')
     covariates: Dict[str, str] = field(default_factory=dict)
     beta_scaling_window: int = field(default=NO_BETA_SCALING)
+    avg_over_days: int = field(default=NO_AVG_OVER)
     algorithm: str = field(default='RK45')
 
     def __post_init__(self):
@@ -35,6 +37,10 @@ class ScenarioSpecification:
         if not isinstance(self.beta_scaling_window, int) or self.beta_scaling_window < -1:
             raise TypeError(f'Beta scaling window must be a positive int or -1 indicating no scaling. '
                             f'Scaling window for scenario {self.name} is {self.beta_scaling_window}.')
+        if not isinstance(self.avg_over_days, int) or self.avg_over_days < -1:
+            raise TypeError(f'Avg over days must be a positive int or -1 indicating that the beta will '
+                            f'not be averaged over any number of days. Avg_over for scenario {self.name} '
+                            f'is {self.avg_over_days}.')
 
     def to_dict(self) -> Dict:
         """Converts to a dict, coercing list-like items to lists."""


### PR DESCRIPTION
According to ticket: https://jira.ihme.washington.edu/browse/GBDSCI-2689

I am not super familiar with working with the specs and dataclasses so I want to check that my assumption is correct that `window_size` and `avg_over` can be set to -1 as their default as a replacement for None (from the docs it seems like these have to be positive ints otherwise). If there is a better way to just set them to none let me know, because that is how they were being evaluated in the beta_shift function from this commit which is what I was basing this off of: https://github.com/ihmeuw/covid-model-seiir-pipeline/compare/10e137d..23843af#diff-e8f17e74967f7f40bfa9b6ec05b7d650R372

Going to test now