### PR TITLE
Fix a couple of bugs in the CLI implementation and reduce a bit of the boilerplate

### DIFF
--- a/src/covid_model_seiir_pipeline/utilities.py
+++ b/src/covid_model_seiir_pipeline/utilities.py
@@ -122,9 +122,10 @@ def get_location_metadata(location_specification: Optional[str],
     Parameters
     ----------
     location_specification
-        Either an id or a path to a location hierarchy file.
+        Either a location set version  id or a path to a location
+        hierarchy file.
     spec_lsvid
-        The location specification version id provided in the run spec.
+        The location set version id provided in the run spec.
     spec_location_file
         The location file provided in the run spec.
 


### PR DESCRIPTION
Motivation: As I started working on the regression integration I encountered a few issues:

1. We're building both the fit and regression specification to run the regression stage, which feels like it's breaking an abstraction layer.
2. The current way of location specification in the regression stage depends on an unversioned file and will break if that file changes between fit and regression.
3. We're pulling a bunch of data we don't need.
4. there were bugs in the run on the cli side.

I'm addressing these in a series of PRs.  This first one is a quick sweep of the cli and utilities.  It:
- swaps boilerplate output options for `cli_tools.add_output_options`
- Combines the location options in ode fit
- Generalizes the behavior of hierarchically overriding defaults with spec arguments and spec arguments with cli arguments (low priority but useful thing to do would be to build this into the `Specification` class.  Requires a little more time and thought)
- Organizes the cli code into clear stages of 1) arg resolution, 2) specification updates, 3) metadata updates, 4) setup and run