### PR TITLE
Collijk/integration/beta fit location handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
 
     internal_requirements = [
         'jobmon',
+        'db_queries',
     ]
 
     setup(

--- a/specification_templates/fit.yaml
+++ b/specification_templates/fit.yaml
@@ -1,6 +1,6 @@
 data:
   infection_version: '2020_06_21.01'
-  location_set_version_id: 727
+  location_set_version_id: ''
   output_root: ''
   location_set_file: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/location_metadata_727.csv'
 parameters:

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -68,7 +68,7 @@ def fit(run_metadata,
     cli_tools.configure_logging_to_files(run_directory)
     main = cli_tools.monitor_application(ode_fit.do_beta_fit,
                                          logger, with_debugger)
-    app_metadata, _ = main(fit_spec, run_directory)
+    app_metadata, _ = main(fit_spec)
 
     run_metadata['app_metadata'] = app_metadata.to_dict()
     run_metadata.dump(run_directory / 'metadata.yaml')

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -29,7 +29,7 @@ def fit(run_metadata,
         fit_specification,
         infection_version,
         location_specification,
-        output_root, mark_dir_as_best, production_tag,
+        output_root, mark_best, production_tag,
         verbose, with_debugger):
     """Runs a beta fit on a set of infection data."""
     cli_tools.configure_logging_to_terminal(verbose)
@@ -72,7 +72,7 @@ def fit(run_metadata,
     run_metadata['app_metadata'] = app_metadata.to_dict()
     run_metadata.dump(run_directory / 'metadata.yaml')
 
-    cli_tools.make_links(app_metadata, run_directory, mark_dir_as_best, production_tag)
+    cli_tools.make_links(app_metadata, run_directory, mark_best, production_tag)
 
     logger.info('**Done**')
 
@@ -94,7 +94,7 @@ def fit(run_metadata,
 def regress(run_metadata,
             regression_specification,
             ode_fit_version, covariates_version,
-            output_root, mark_dir_as_best, production_tag,
+            output_root, mark_best, production_tag,
             verbose, with_debugger):
     """Perform beta regression for a set of infections and covariates."""
     cli_tools.configure_logging_to_terminal(verbose)
@@ -135,7 +135,7 @@ def regress(run_metadata,
     run_metadata['app_metadata'] = app_metadata.to_dict()
     run_metadata.dump(run_directory / 'metadata.yaml')
 
-    cli_tools.make_links(app_metadata, run_directory, mark_dir_as_best, production_tag)
+    cli_tools.make_links(app_metadata, run_directory, mark_best, production_tag)
 
     logger.info('**Done**')
 
@@ -153,7 +153,7 @@ def regress(run_metadata,
 def forecast(run_metadata,
              forecast_specification,
              regression_version,
-             output_root, mark_dir_as_best, production_tag,
+             output_root, mark_best, production_tag,
              verbose, with_debugger):
     """Perform beta forecast for a set of scenarios on a regression."""
     cli_tools.configure_logging_to_terminal(verbose)
@@ -184,6 +184,6 @@ def forecast(run_metadata,
     run_metadata['app_metadata'] = app_metadata.to_dict()
     run_metadata.dump(run_directory / 'metadata.yaml')
 
-    cli_tools.make_links(app_metadata, run_directory, mark_dir_as_best, production_tag)
+    cli_tools.make_links(app_metadata, run_directory, mark_best, production_tag)
 
     logger.info('**Done**')

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -4,8 +4,6 @@ from loguru import logger
 
 from covid_model_seiir_pipeline import regression, ode_fit, forecasting, utilities
 
-DEFAULT_SEIIR_OUTPUT_ROOT = '/ihme/scratch/users/miker985/seiir-tests'
-
 
 @click.group()
 def seiir():

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -15,6 +15,7 @@ def seiir():
 @click.argument('fit_specification')
 @click.option('--infection-version',
               type=click.Path(file_okay=False),
+              default=paths.BEST_LINK,
               help="Which version of infectionator inputs to use in the"
                    "regression.")
 @click.option('-l', '--location-specification',
@@ -22,7 +23,7 @@ def seiir():
               help="Either a location set version id used to pull a list of"
                    "locations to run, or a full path to a file describing"
                    "the location set.")
-@cli_tools.add_output_options
+@cli_tools.add_output_options(paths.SEIR_FIT_OUTPUTS)
 @cli_tools.add_verbose_and_with_debugger
 def fit(run_metadata,
         fit_specification,
@@ -45,8 +46,7 @@ def fit(run_metadata,
         fit_spec.data.location_set_version_id,
         fit_spec.data.location_set_file
     )
-    output_root = utilities.get_output_root(output_root, fit_spec.data.output_root,
-                                            paths.SEIR_FIT_OUTPUTS)
+    output_root = utilities.get_output_root(output_root, fit_spec.data.output_root)
     cli_tools.setup_directory_structure(output_root, with_production=True)
     run_directory = cli_tools.make_run_directory(output_root)
 
@@ -89,7 +89,7 @@ def fit(run_metadata,
               type=click.Path(file_okay=False),
               help=('Which version of the covariates to use in the '
                     'regression.'))
-@cli_tools.add_output_options
+@cli_tools.add_output_options(paths.SEIR_REGRESSION_OUTPUTS)
 @cli_tools.add_verbose_and_with_debugger
 def regress(run_metadata,
             regression_specification,
@@ -110,8 +110,7 @@ def regress(run_metadata,
                                                regression_spec.data.covariate_version,
                                                paths.SEIR_COVARIATES_OUTPUT_ROOT)
     output_root = utilities.get_output_root(output_root,
-                                            regression_spec.data.output_root,
-                                            paths.SEIR_REGRESSION_OUTPUTS)
+                                            regression_spec.data.output_root)
     cli_tools.setup_directory_structure(output_root, with_production=True)
     run_directory = cli_tools.make_run_directory(output_root)
 
@@ -149,7 +148,7 @@ def regress(run_metadata,
               type=click.Path(file_okay=False),
               help="Which version of ode fit inputs to use in the"
                    "regression.")
-@cli_tools.add_output_options
+@cli_tools.add_output_options(paths.SEIR_FORECAST_OUTPUTS)
 @cli_tools.add_verbose_and_with_debugger
 def forecast(run_metadata,
              forecast_specification,
@@ -165,8 +164,7 @@ def forecast(run_metadata,
                                                forecast_spec.data.regression_version,
                                                paths.SEIR_REGRESSION_OUTPUTS)
     output_root = utilities.get_output_root(output_root,
-                                            forecast_spec.data.output_root,
-                                            paths.SEIR_FORECAST_OUTPUTS)
+                                            forecast_spec.data.output_root)
     cli_tools.setup_directory_structure(output_root, with_production=True)
     run_directory = cli_tools.make_run_directory(output_root)
 

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -17,7 +17,6 @@ def seiir():
 @click.argument('fit_specification')
 @click.option('--infection-version',
               type=click.Path(file_okay=False),
-              default=paths.BEST_LINK,
               help="Which version of infectionator inputs to use in the"
                    "regression.")
 @click.option('-l', '--location-specification',

--- a/src/covid_model_seiir_pipeline/ode_fit/data.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/data.py
@@ -27,6 +27,9 @@ class ODEDataInterface:
             location_metadata = pd.read_csv(location_file)
         else:
             location_metadata = None
+
+        if location_metadata is not None:
+            location_metadata = location_metadata[location_metadata.most_detailed == 1]
         return location_metadata
 
     def filter_location_ids(self, desired_locations: List[int] = None) -> List[int]:
@@ -102,7 +105,5 @@ class ODEDataInterface:
         # Hide this import so the code stays portable outside IHME by using
         # a locations file directly.
         from db_queries import get_location_metadata
-        hierarchy = get_location_metadata(location_set_id=111,
-                                          location_set_version_id=location_set_version_id)
-        most_detailed_locs = hierarchy.loc[hierarchy.most_detailed == 1]
-        return most_detailed_locs
+        return get_location_metadata(location_set_id=111,
+                                     location_set_version_id=location_set_version_id)

--- a/src/covid_model_seiir_pipeline/ode_fit/data.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/data.py
@@ -1,35 +1,60 @@
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Optional, Union
 
 from loguru import logger
 import pandas as pd
 import yaml
 
 from covid_model_seiir_pipeline.static_vars import INFECTION_COL_DICT
-from covid_model_seiir_pipeline.paths import ODEPaths, InfectionPaths
+from covid_model_seiir_pipeline import paths
 
 
 class ODEDataInterface:
 
-    def __init__(self, ode_fit_root: Path, infection_root: Path, location_file: Path) -> None:
-        self.ode_paths = ODEPaths(ode_fit_root)
-        self.infection_paths = InfectionPaths(infection_root)
-        self.location_metadata_file = location_file
+    def __init__(self, ode_paths: paths.ODEPaths,
+                 infection_paths: paths.InfectionPaths) -> None:
+        self.ode_paths = ode_paths
+        self.infection_paths = infection_paths
 
-    def load_location_ids(self) -> List[int]:
+    def load_location_metadata(self, location_set_version_id: Optional[int],
+                               location_file: Optional[Union[str, Path]]) -> Union[pd.DataFrame, None]:
+        """Retrieve a location hierarchy from a file or from GBD if specified."""
+        # TODO: Remove after integration testing.
+        assert not (location_set_version_id and location_file), 'CLI location validation is broken.'
+        if location_set_version_id:
+            location_metadata = self._load_from_location_set_version_id(location_set_version_id)
+        elif location_file:
+            location_metadata = pd.read_csv(location_file)
+        else:
+            location_metadata = None
+        return location_metadata
+
+    def filter_location_ids(self, desired_locations: List[int] = None) -> List[int]:
         """Get the list of location ids to model.
 
-        This list is the intersection of a location hierarchy file and
-        the available locations in the infections directory.
+        This list is the intersection of a location metadata's
+        locations, if provided, and the available locations in the infections
+        directory.
 
         """
-        desired_locs = pd.read_csv(self.location_metadata_file)["location_id"].tolist()
-        modeled_locs = self.infection_paths.get_modelled_locations()
-        missing_locs = list(set(desired_locs).difference(modeled_locs))
-        if missing_locs:
+        modeled_locations = self.infection_paths.get_modelled_locations()
+        if desired_locations is None:
+            desired_locations = modeled_locations
+
+        missing_locations = list(set(desired_locations).difference(modeled_locations))
+        if missing_locations:
             logger.warning("Some locations present in location metadata are missing from the "
-                           f"infection models. Missing locations are {missing_locs}.")
-        return list(set(desired_locs).intersection(modeled_locs))
+                           f"infection models. Missing locations are {sorted(missing_locations)}.")
+        return list(set(desired_locations).intersection(modeled_locations))
+
+    def load_location_ids(self) -> List[int]:
+        with self.ode_paths.location_metadata.open() as location_file:
+            location_ids = yaml.full_load(location_file)
+        return location_ids
+
+    def dump_location_ids(self, location_ids: List[int]):
+        with self.ode_paths.location_metadata.open('w') as location_file:
+            yaml.dump(location_ids, location_file)
 
     def load_all_location_data(self, location_ids: List[int], draw_id: int
                                ) -> Dict[int, pd.DataFrame]:
@@ -72,3 +97,12 @@ class ODEDataInterface:
         with (self.ode_paths.root_dir / 'locations.yaml') as location_file:
             yaml.dump({'locations': locations},location_file)
 
+    @staticmethod
+    def _load_from_location_set_version_id(location_set_version_id: int) -> pd.DataFrame:
+        # Hide this import so the code stays portable outside IHME by using
+        # a locations file directly.
+        from db_queries import get_location_metadata
+        hierarchy = get_location_metadata(location_set_id=111,
+                                          location_set_version_id=location_set_version_id)
+        most_detailed_locs = hierarchy.loc[hierarchy.most_detailed == 1]
+        return most_detailed_locs

--- a/src/covid_model_seiir_pipeline/ode_fit/data.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/data.py
@@ -16,8 +16,8 @@ class ODEDataInterface:
         self.ode_paths = ode_paths
         self.infection_paths = infection_paths
 
-    def load_location_metadata(self, location_set_version_id: Optional[int],
-                               location_file: Optional[Union[str, Path]]) -> Union[pd.DataFrame, None]:
+    def load_location_ids_from_primary_source(self, location_set_version_id: Optional[int],
+                                              location_file: Optional[Union[str, Path]]) -> Union[List[int], None]:
         """Retrieve a location hierarchy from a file or from GBD if specified."""
         # TODO: Remove after integration testing.
         assert not (location_set_version_id and location_file), 'CLI location validation is broken.'
@@ -29,7 +29,7 @@ class ODEDataInterface:
             location_metadata = None
 
         if location_metadata is not None:
-            location_metadata = location_metadata[location_metadata.most_detailed == 1]
+            location_metadata = location_metadata.loc[location_metadata.most_detailed == 1, 'location_id'].tolist()
         return location_metadata
 
     def filter_location_ids(self, desired_locations: List[int] = None) -> List[int]:

--- a/src/covid_model_seiir_pipeline/ode_fit/main.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/main.py
@@ -1,4 +1,6 @@
 """Runner for the beta ODE fit."""
+from pathlib import Path
+
 from covid_shared import cli_tools
 from loguru import logger
 
@@ -13,8 +15,8 @@ def do_beta_fit(app_metadata: cli_tools.Metadata,
     logger.debug('Starting Beta fit.')
 
     # init high level objects
-    ode_paths = paths.ODEPaths(fit_specification.data.output_root, read_only=False)
-    infection_paths = paths.InfectionPaths(fit_specification.data.output_root)
+    ode_paths = paths.ODEPaths(Path(fit_specification.data.output_root), read_only=False)
+    infection_paths = paths.InfectionPaths(Path(fit_specification.data.infection_version))
 
     data_interface = ODEDataInterface(
         ode_paths=ode_paths,
@@ -22,7 +24,7 @@ def do_beta_fit(app_metadata: cli_tools.Metadata,
     )
 
     # Grab canonical location list from arguments
-    location_metadata = data_interface.load_location_metadata(
+    location_metadata = data_interface.load_location_ids_from_primary_source(
         location_set_version_id=fit_specification.data.location_set_version_id,
         location_file=fit_specification.data.location_set_file
     )

--- a/src/covid_model_seiir_pipeline/ode_fit/main.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/main.py
@@ -1,32 +1,40 @@
 """Runner for the beta ODE fit."""
-from pathlib import Path
-
 from covid_shared import cli_tools
 from loguru import logger
 
 from covid_model_seiir_pipeline.ode_fit import FitSpecification
-from covid_model_seiir_pipeline.paths import ODEPaths
+from covid_model_seiir_pipeline import paths
 from covid_model_seiir_pipeline.ode_fit.data import ODEDataInterface
 from covid_model_seiir_pipeline.ode_fit.workflow import ODEFitWorkflow
 
 
 def do_beta_fit(app_metadata: cli_tools.Metadata,
-                fit_specification: FitSpecification,
-                output_root: Path):
+                fit_specification: FitSpecification):
     logger.debug('Starting Beta fit.')
+
     # init high level objects
-    ode_paths = ODEPaths(output_root, read_only=False)
+    ode_paths = paths.ODEPaths(fit_specification.data.output_root, read_only=False)
+    infection_paths = paths.InfectionPaths(fit_specification.data.output_root)
+
     data_interface = ODEDataInterface(
-        ode_fit_root=Path(fit_specification.data.output_root),
-        infection_root=Path(fit_specification.data.infection_version),
-        location_file=Path(fit_specification.data.location_set_file)
+        ode_paths=ode_paths,
+        infection_paths=infection_paths,
     )
 
-    # build directory structure
-    location_ids = data_interface.load_location_ids()
+    # Grab canonical location list from arguments
+    location_metadata = data_interface.load_location_metadata(
+        location_set_version_id=fit_specification.data.location_set_version_id,
+        location_file=fit_specification.data.location_set_file
+    )
+    # Filter to the intersection of what's available from the infection data.
+    location_ids = data_interface.filter_location_ids(location_metadata)
+    # Setup directory structure and save location and specification data.
     ode_paths.make_dirs(location_ids)
+    data_interface.dump_location_ids(location_ids)
+    # Fixme: Inconsistent data writing interfaces
+    fit_specification.dump(ode_paths.fit_specification)
 
     # build workflow and launch
-    ode_wf = ODEFitWorkflow(fit_specification)
-    ode_wf.attach_ode_tasks()
+    ode_wf = ODEFitWorkflow(fit_specification.data.output_root)
+    ode_wf.attach_ode_tasks(fit_specification.parameters.n_draws)
     ode_wf.run()

--- a/src/covid_model_seiir_pipeline/ode_fit/task.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/task.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import numpy as np
 
+from covid_model_seiir_pipeline import paths
 from covid_model_seiir_pipeline.ode_fit import FitSpecification, model
 from covid_model_seiir_pipeline.ode_fit.data import ODEDataInterface
 from covid_model_seiir_pipeline.static_vars import INFECTION_COL_DICT
@@ -20,14 +21,12 @@ def run_ode_fit(draw_id: int, ode_version: str):
     fit_specification: FitSpecification = FitSpecification.from_path(
         Path(ode_version) / "fit_specification.yaml"
     )
-    data_interface = ODEDataInterface(
-        ode_fit_root=Path(fit_specification.data.output_root),
-        infection_root=Path(fit_specification.data.infection_version),
-        location_file=Path(fit_specification.data.location_set_file)
-    )
+    ode_paths = paths.ODEPaths(fit_specification.data.output_root)
+    infection_paths = paths.InfectionPaths(fit_specification.data.infection_version)
+    data_interface = ODEDataInterface(ode_paths=ode_paths, infection_paths=infection_paths)
 
     # Load data
-    location_ids = data_interface.load_location_ids()
+    location_ids = data_interface.load_location_ids(location_file=ode_paths.location_metadata)
     location_data = data_interface.load_all_location_data(location_ids=location_ids,
                                                           draw_id=draw_id)
 

--- a/src/covid_model_seiir_pipeline/ode_fit/task.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/task.py
@@ -26,7 +26,7 @@ def run_ode_fit(draw_id: int, ode_version: str):
     data_interface = ODEDataInterface(ode_paths=ode_paths, infection_paths=infection_paths)
 
     # Load data
-    location_ids = data_interface.load_location_ids(location_file=ode_paths.location_metadata)
+    location_ids = data_interface.load_location_ids()
     location_data = data_interface.load_all_location_data(location_ids=location_ids,
                                                           draw_id=draw_id)
 

--- a/src/covid_model_seiir_pipeline/ode_fit/task.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/task.py
@@ -21,8 +21,8 @@ def run_ode_fit(draw_id: int, ode_version: str):
     fit_specification: FitSpecification = FitSpecification.from_path(
         Path(ode_version) / "fit_specification.yaml"
     )
-    ode_paths = paths.ODEPaths(fit_specification.data.output_root)
-    infection_paths = paths.InfectionPaths(fit_specification.data.infection_version)
+    ode_paths = paths.ODEPaths(Path(fit_specification.data.output_root))
+    infection_paths = paths.InfectionPaths(Path(fit_specification.data.infection_version))
     data_interface = ODEDataInterface(ode_paths=ode_paths, infection_paths=infection_paths)
 
     # Load data

--- a/src/covid_model_seiir_pipeline/ode_fit/workflow.py
+++ b/src/covid_model_seiir_pipeline/ode_fit/workflow.py
@@ -5,7 +5,6 @@ from jobmon.client.swarm.executors.base import ExecutorParameters
 from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
 
 from covid_model_seiir_pipeline import utilities
-from covid_model_seiir_pipeline.ode_fit import FitSpecification
 
 
 class ODEFitTaskTemplate:
@@ -19,7 +18,6 @@ class ODEFitTaskTemplate:
         )
         self.params = ExecutorParameters(
             max_runtime_seconds=3000,
-            j_resource=False,
             m_mem_free='20G',
             num_cores=3,
             queue='d.q'
@@ -44,18 +42,12 @@ class ODEFitTaskTemplate:
 
 class ODEFitWorkflow:
 
-    def __init__(self, fit_specification: FitSpecification):
-        self.fit_specification = fit_specification
-
-        # if we need to build dependencies then the task registry must be shared between
-        # task factories
+    def __init__(self, version: str):
+        self.version = version
         self._ode_fit_task_template = ODEFitTaskTemplate()
 
-        # TODO: figure out where to put these defaults
-        # TODO: configure logging to go to output_root
-        workflow_args = f'seiir-model-{fit_specification.data.output_root}'
-        stdout, stderr = utilities.make_log_dirs(self.fit_specification.data.output_root,
-                                                 prefix='jobmon')
+        workflow_args = f'seiir-model-{version}'
+        stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
 
         self.workflow = Workflow(
             workflow_args=workflow_args,
@@ -66,9 +58,9 @@ class ODEFitWorkflow:
             resume=True
         )
 
-    def attach_ode_tasks(self):
-        for draw_id in range(self.fit_specification.parameters.n_draws):
-            task = self._ode_fit_task_template.get_task(draw_id, self.fit_specification.data.output_root)
+    def attach_ode_tasks(self, n_draws: int):
+        for draw_id in range(n_draws):
+            task = self._ode_fit_task_template.get_task(draw_id, self.version)
             self.workflow.add_task(task)
 
     def run(self):

--- a/src/covid_model_seiir_pipeline/paths.py
+++ b/src/covid_model_seiir_pipeline/paths.py
@@ -1,7 +1,7 @@
 import abc
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, ClassVar, Dict
+from typing import List, ClassVar, Dict, Union
 
 from parse import parse
 
@@ -15,8 +15,11 @@ class Paths:
     local directory structures.
 
     """
-    root_dir: Path
+    root_dir: Union[str, Path]
     read_only: bool = field(default=True)
+
+    def __post_init__(self):
+        self.root_dir = Path(self.root_dir)
 
     @property
     @abc.abstractmethod
@@ -146,6 +149,14 @@ class ODEPaths(Paths):
     draw_date_file: ClassVar[str] = 'dates_draw_{draw_id}.csv'
 
     @property
+    def location_metadata(self) -> Path:
+        return self.root_dir / 'locations.yaml'
+
+    @property
+    def fit_specification(self):
+        return self.root_dir / 'fit_specification.yaml'
+
+    @property
     def beta_fit_dir(self) -> Path:
         return self.root_dir / 'betas'
 
@@ -168,13 +179,9 @@ class ODEPaths(Paths):
         return self.date_dir / self.draw_date_file.format(draw_id=draw_id)
 
     @property
-    def diagnostic_dir(self) -> Path:
-        return self.root_dir / 'diagnostics'
-
-    @property
     def directories(self) -> List[Path]:
         """Returns all top level sub-directories."""
-        return [self.beta_fit_dir, self.parameters_dir, self.diagnostic_dir, self.date_dir]
+        return [self.beta_fit_dir, self.parameters_dir, self.date_dir]
 
     @property
     def location_specific_directories(self) -> List[Path]:

--- a/src/covid_model_seiir_pipeline/utilities.py
+++ b/src/covid_model_seiir_pipeline/utilities.py
@@ -109,7 +109,6 @@ def get_input_root(cli_argument: Optional[str], specification_value: Optional[st
 
     """
     version = get_argument_hierarchically(cli_argument, specification_value, paths.BEST_LINK)
-    version = Path(version).resolve()
     root = cli_tools.get_last_stage_directory(version, last_stage_root=last_stage_root)
     return root.resolve()
 

--- a/src/covid_model_seiir_pipeline/utilities.py
+++ b/src/covid_model_seiir_pipeline/utilities.py
@@ -152,15 +152,15 @@ def get_location_metadata(location_specification: Optional[str],
     return lsvid, location_file
 
 
-def get_output_root(cli_argument: Optional[str], specification_value: Optional[str],
-                    default: Union[str, Path]) -> Path:
+def get_output_root(cli_argument: Optional[str], specification_value: Optional[str]) -> Path:
     """Determine the output root hierarchically.
 
     CLI arguments override specification args.  Specification args override
     the default.
 
     """
-    version = get_argument_hierarchically(cli_argument, specification_value, default)
+    # Default behavior handled by CLI.
+    version = get_argument_hierarchically(cli_argument, specification_value, cli_argument)
     version = Path(version).resolve()
     return version
 


### PR DESCRIPTION
The primary work here is to get location handling working properly.  

How this works:
- Default behavior: if no location info is specified, we use all locations modeled by the infectionator.
- In the fit specification there is a `location_set_version_id` key and a `location_file` key. 
  - If both are specified, we fail
  - if  `location_set_version_id` is specified, we pull from GBD, subset to most detailed, intersect with locs available from infectionator (warning about missing locations)
  - if `location_file` is specified, we read in the file, subset to most detailed, intersect with locs available from infectoinator (warning about missing locations)
- At the command line there is a `-l` or `--location-specification` argument
  - Defaults to None
  - If an int is specified, the fit specification is updated to use as the `location_set_version_id`
  - If a path is specified, the fit specification is updated to use as the `location_file`

The main function loads the location list from primary sources and then writes them out to a `locations.yaml` in the run directory.  The individual tasks read the location list from the run directory.


Other things here:
- Some bugfixes in the cli arg handling
- Simplification of some of the object usage (swapping custom objects for standard types where reasonable) to better facilitate testing.

**Validation**: Ran and passed integration notebook (exact equality with last integration test outputs produced by the production code).