### PR TITLE
Extract beta hat computation, clean up regressors a bit

### DIFF
--- a/src/covid_model_seiir_pipeline/model_runner.py
+++ b/src/covid_model_seiir_pipeline/model_runner.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from covid_model_seiir_pipeline.forecasting.model import ODERunner
 
 
@@ -41,3 +43,33 @@ class ModelRunner:
         """
         forecaster = ODERunner(model_specs, init_cond, dt=dt)
         return forecaster.get_solution(times, beta=betas, theta=thetas)
+
+
+# FIXME: The only "modeling" code shared between the stages.  Where to put it?
+def compute_beta_hat(covariates: pd.DataFrame, coefficients: pd.DataFrame) -> pd.Series:
+    """Computes beta from a set of covariates and their coefficients.
+
+    We're leveraging regression coefficients and past or future values for
+    covariates to produce a modelled beta (beta hat). Past data is used
+    in the original regression to produce the coefficients so that beta hat
+    best matches the data.
+
+    .. math::
+
+        \hat{\beta}(location, time) = \sum\limits_{c \in cov} coeff_c(location) * covariate_c(location, time)
+
+    Parameters
+    ----------
+    covariates
+        DataFrame with columns 'location_id', 'date', and a column for
+        each covariate. A time series for the covariate values by location.
+    coefficients
+        DataFrame with a 'location_id' column and a column for each covariate
+        representing the strength of the relationship between the covariate
+        and beta.
+
+    """
+    covariates = covariates.set_index(['location_id', 'date']).sort_index()
+    covariates['intercept'] = 1.0
+    coefficients = coefficients.set_index(['location_id']).sort_index()
+    return (covariates * coefficients).sum(axis=1)

--- a/src/covid_model_seiir_pipeline/regression/model/__init__.py
+++ b/src/covid_model_seiir_pipeline/regression/model/__init__.py
@@ -5,7 +5,6 @@ from .ode_fit import (
 from .regress import (
     BetaRegressor,
     BetaRegressorSequential,
-    compute_beta_hat,
     align_beta_with_covariates,
     build_regressor,
 )

--- a/src/covid_model_seiir_pipeline/regression/model/__init__.py
+++ b/src/covid_model_seiir_pipeline/regression/model/__init__.py
@@ -5,7 +5,7 @@ from .ode_fit import (
 from .regress import (
     BetaRegressor,
     BetaRegressorSequential,
-    predict,
+    compute_beta_hat,
     align_beta_with_covariates,
     build_regressor,
 )

--- a/src/covid_model_seiir_pipeline/regression/model/regress.py
+++ b/src/covid_model_seiir_pipeline/regression/model/regress.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import copy
-from pprint import pprint
 from typing import Iterable, List, Union
 
 import pandas as pd
@@ -11,60 +10,50 @@ from slime.model import CovModelSet, CovModel, MRModel
 from covid_model_seiir_pipeline.regression.specification import CovariateSpecification
 
 
-class BetaRegressor:
+class CovariateModel(CovModel):
+    """Adapter around slime CovModel to translate covariate specs."""
 
-    def __init__(self, covmodel_set):
+    @classmethod
+    def from_specification(cls, covariate: CovariateSpecification):
+        return cls(
+            col_cov=covariate.name,
+            use_re=covariate.use_re,
+            bounds=np.array(covariate.bounds),
+            gprior=np.array(covariate.gprior),
+            re_var=covariate.re_var,
+        )
+
+
+class IBetaRegressor:
+
+    def fit(self, mr_data: MRData) -> pd.DataFrame:
+        raise NotImplementedError
+
+
+class BetaRegressor(IBetaRegressor):
+
+    def __init__(self, covmodel_set: CovModelSet):
         self.covmodel_set = covmodel_set
         self.col_covs = [covmodel.col_cov for covmodel in covmodel_set.cov_models]
 
-    def fit_no_random(self, mr_data, verbose=True):
-        self.covmodel_set_fixed = copy.deepcopy(self.covmodel_set)
-        for covmodel in self.covmodel_set_fixed.cov_models:
+    def fit_no_random(self, mr_data: MRData) -> np.ndarray:
+        covmodel_set_fixed = copy.deepcopy(self.covmodel_set)
+        for covmodel in covmodel_set_fixed.cov_models:
             covmodel.use_re = False
+        mr_model_fixed = MRModel(mr_data, covmodel_set_fixed)
+        mr_model_fixed.fit_model()
+        return list(mr_model_fixed.result.values())[0]
 
-        self.mr_model_fixed = MRModel(mr_data, self.covmodel_set_fixed)
-        self.mr_model_fixed.fit_model()
-
-        y = mr_data.df[mr_data.col_obs].to_numpy()
-        X = mr_data.df[[covmodel.col_cov for covmodel in self.covmodel_set_fixed.cov_models]].to_numpy()
-        s = mr_data.df[mr_data.col_obs_se].to_numpy()
-        coef = np.linalg.solve(np.dot(np.transpose(X)/s**2, X), np.dot(np.transpose(X)/s**2, y))
-        self.cov_coef_fixed = list(self.mr_model_fixed.result.values())[0]
-        if verbose:
-            print('by hand', coef)
-            print('from slime', self.cov_coef_fixed)
-
-    def fit(self, mr_data, verbose=False):
-        self.mr_model = MRModel(mr_data, self.covmodel_set)
-        self.mr_model.fit_model()
-        self.cov_coef = self.mr_model.result
-        if verbose:
-            pprint(self.cov_coef)
-            print()
-        coef = pd.DataFrame.from_dict(self.cov_coef, orient='index').reset_index()
-        coef.columns = ['group_id'] + self.col_covs
+    def fit(self, mr_data: MRData) -> pd.DataFrame:
+        mr_model = MRModel(mr_data, self.covmodel_set)
+        mr_model.fit_model()
+        cov_coef = mr_model.result
+        coef = pd.DataFrame.from_dict(cov_coef, orient='index').reset_index()
+        coef.columns = ['location_id'] + self.col_covs
         return coef
 
-    def load_coef(self, df=None, path=None):
-        if df is None:
-            assert path is not None
-            df = pd.read_csv(path)
-        assert 'group_id' in df
-        cov_coef_dict = df.set_index('group_id').to_dict(orient='index')
-        self.cov_coef = {}
-        for k, v in cov_coef_dict.items():
-            coef = [v[cov] for cov in self.col_covs]
-            self.cov_coef[k] = coef
 
-    def predict(self, cov, group):
-        if group in self.cov_coef:
-            assert cov.shape[1] == len(self.cov_coef[group])
-            return np.sum([self.cov_coef[group][i]*cov[:, i] for i in range(cov.shape[1])], axis=0)
-        else:
-            raise RuntimeError('Group Not Found.')
-
-
-class BetaRegressorSequential:
+class BetaRegressorSequential(IBetaRegressor):
 
     def __init__(self, ordered_covmodel_sets, default_std=1.0):
         self.default_std = default_std
@@ -73,7 +62,7 @@ class BetaRegressorSequential:
         for covmodel_set in self.ordered_covmodel_sets:
             self.col_covs.extend([covmodel.col_cov for covmodel in covmodel_set.cov_models])
 
-    def fit(self, mr_data, verbose=False):
+    def fit(self, mr_data) -> pd.DataFrame:
         covmodels = []
         covmodel_bounds = []
         covmodel_gprior_std = []
@@ -85,17 +74,10 @@ class BetaRegressorSequential:
                 covmodel_gprior_std.append(cov_model.gprior[1])
                 cov_model.gprior[1] = np.inf
             regressor = BetaRegressor(covmodel_set)
-            if verbose:
-                print('='*20)
-                for covmodel in regressor.covmodel_set.cov_models:
-                    print(covmodel.col_cov,
-                          'gprior:', covmodel.gprior,
-                          'bounds:', covmodel.bounds)
-
-            regressor.fit_no_random(mr_data, verbose=verbose)
+            cov_coef_fixed = regressor.fit_no_random(mr_data)
 
             for covmodel, coef in zip(covmodel_set.cov_models[len(covmodels):],
-                                      regressor.cov_coef_fixed[len(covmodels):]):
+                                      cov_coef_fixed[len(covmodels):]):
                 covmodel.gprior[0] = coef
                 covmodel.bounds = np.array([coef, coef])
             covmodels = covmodel_set.cov_models
@@ -103,41 +85,8 @@ class BetaRegressorSequential:
         for i, cov_model in enumerate(covmodels):
             cov_model.bounds = np.array(covmodel_bounds[i])
             cov_model.gprior[1] = covmodel_gprior_std[i]
-        self.regressor = BetaRegressor(CovModelSet(covmodels))
-        if verbose:
-            print('='*20)
-            for covmodel in self.regressor.covmodel_set.cov_models:
-                print(covmodel.col_cov,
-                      'gprior:', covmodel.gprior,
-                      'bounds:', covmodel.bounds)
-        self.regressor.fit(mr_data, verbose)
-        self.cov_coef = self.regressor.cov_coef
-
-    def predict(self, cov, group):
-        return self.regressor.predict(cov, group)
-
-
-def predict(regressor, df_cov, col_t, col_group, col_beta='beta_pred'):
-    df = df_cov.sort_values(by=[col_group, col_t])
-    df['intercept'] = 1.0
-    groups = df[col_group].unique()
-    col_covs = regressor.col_covs
-
-    beta_pred = []
-
-    for group in groups:
-        df_one_group = df[df[col_group] == group]
-        if group in regressor.cov_coef:
-            cov = df_one_group[col_covs].to_numpy()
-            betas = regressor.predict(cov, group)
-            beta_pred.append(betas)
-        else:
-            beta_pred.append([np.nan]*df_one_group.shape[0])
-
-    beta_pred = np.concatenate(beta_pred)
-    df[col_beta] = beta_pred
-
-    return df
+        regressor = BetaRegressor(CovModelSet(covmodels))
+        return regressor.fit(mr_data)
 
 
 def align_beta_with_covariates(covariate_df: pd.DataFrame,
@@ -161,13 +110,7 @@ def build_regressor(covariates: Iterable[CovariateSpecification]) -> Union[BetaR
     # construct each CovModel independently. add to dict of list by covariate order
     covariate_models = defaultdict(list)
     for covariate in covariates:
-        cov_model = CovModel(
-            col_cov=covariate.name,
-            use_re=covariate.use_re,
-            bounds=np.array(covariate.bounds),
-            gprior=np.array(covariate.gprior),
-            re_var=covariate.re_var,
-        )
+        cov_model = CovariateModel.from_specification(covariate)
         covariate_models[covariate.order].append(cov_model)
     ordered_covmodel_sets = [CovModelSet(covariate_group)
                              for _, covariate_group in sorted(covariate_models.items())]


### PR DESCRIPTION
Okay.  So.  There is one bit of modeling code shared between the forecast and regression stages and that's the computation of beta hat from coefficients and covariates.  This is literally just element-wise matrix multiplication and then a sum over columns.

This PR does one important thing:

- Pulls that computation out of the regressors/predict function and into a shared function.

This PR does two less important things, because I was already there and trying to make sense of the code:
- Makes a tiny adapter around the CovModelSet to bridge our specification abstraction and the abstraction in slime.
- Refactor the regressor classes in three ways:
  - Strip out a lot of unneccesary debug code
  - Give those classes a literal common interface.
  - Favor functional application over imperative `model.fit` calls that attach new data pieces to the regressor objects.

There's still some work to be done on these (e.g. the `BetaRegressorSequential.fit` method consumes one of its attributes, which seems problematic for testing), but it's deep in the stack and not super important right this very second.