### PR TITLE
Collijk/feature/dry run

### DIFF
--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -32,12 +32,18 @@ def seiir():
               help="Either a location set version id used to pull a list of"
                    "locations to run, or a full path to a file describing"
                    "the location set.")
+@click.option('--preprocess-only',
+              is_flag=True,
+              help="Only make the directory and set up the metadata. "
+                   "Useful for setting up output directories for testing "
+                   "tasks individually.")
 @cli_tools.add_output_options(paths.SEIR_REGRESSION_OUTPUTS)
 @cli_tools.add_verbose_and_with_debugger
 def regress(run_metadata,
             regression_specification,
             infection_version, covariates_version,
             location_specification,
+            preprocess_only,
             output_root, mark_best, production_tag,
             verbose, with_debugger):
     """Perform beta regression for a set of infections and covariates."""
@@ -79,7 +85,7 @@ def regress(run_metadata,
     cli_tools.configure_logging_to_files(run_directory)
     main = cli_tools.monitor_application(do_beta_regression,
                                          logger, with_debugger)
-    app_metadata, _ = main(regression_spec)
+    app_metadata, _ = main(regression_spec, preprocess_only)
 
     run_metadata['app_metadata'] = app_metadata.to_dict()
     run_metadata.dump(run_directory / 'metadata.yaml')
@@ -101,12 +107,18 @@ def regress(run_metadata,
               type=click.Path(file_okay=False),
               help=('Which version of the covariates to use in the '
                     'regression.'))
+@click.option('--preprocess-only',
+              is_flag=True,
+              help="Only make the directory and set up the metadata. "
+                   "Useful for setting up output directories for testing "
+                   "tasks individually.")
 @cli_tools.add_output_options(paths.SEIR_FORECAST_OUTPUTS)
 @cli_tools.add_verbose_and_with_debugger
 def forecast(run_metadata,
              forecast_specification,
              regression_version,
              covariates_version,
+             preprocess_only,
              output_root, mark_best, production_tag,
              verbose, with_debugger):
     """Perform beta forecast for a set of scenarios on a regression."""
@@ -136,7 +148,7 @@ def forecast(run_metadata,
     cli_tools.configure_logging_to_files(run_directory)
     main = cli_tools.monitor_application(do_beta_forecast,
                                          logger, with_debugger)
-    app_metadata, _ = main(forecast_spec)
+    app_metadata, _ = main(forecast_spec, preprocess_only)
 
     run_metadata['app_metadata'] = app_metadata.to_dict()
     run_metadata.dump(run_directory / 'metadata.yaml')

--- a/src/covid_model_seiir_pipeline/forecasting/main.py
+++ b/src/covid_model_seiir_pipeline/forecasting/main.py
@@ -7,7 +7,8 @@ from covid_model_seiir_pipeline.forecasting.workflow import ForecastWorkflow
 
 
 def do_beta_forecast(app_metadata: cli_tools.Metadata,
-                     forecast_specification: ForecastSpecification):
+                     forecast_specification: ForecastSpecification,
+                     preprocess_only: bool):
     logger.debug('Starting beta forecast.')
 
     data_interface = ForecastDataInterface.from_specification(forecast_specification)
@@ -20,8 +21,9 @@ def do_beta_forecast(app_metadata: cli_tools.Metadata,
     # Fixme: Inconsistent data writing interfaces
     forecast_specification.dump(data_interface.forecast_paths.forecast_specification)
 
-    forecast_wf = ForecastWorkflow(forecast_specification.data.output_root)
-    n_draws = data_interface.get_n_draws()
-    forecast_wf.attach_scenario_tasks(n_draws=n_draws,
-                                      scenarios=list(forecast_specification.scenarios))
-    forecast_wf.run()
+    if not preprocess_only:
+        forecast_wf = ForecastWorkflow(forecast_specification.data.output_root)
+        n_draws = data_interface.get_n_draws()
+        forecast_wf.attach_scenario_tasks(n_draws=n_draws,
+                                          scenarios=list(forecast_specification.scenarios))
+        forecast_wf.run()

--- a/src/covid_model_seiir_pipeline/regression/main.py
+++ b/src/covid_model_seiir_pipeline/regression/main.py
@@ -7,7 +7,8 @@ from covid_model_seiir_pipeline.regression.workflow import RegressionWorkflow
 
 
 def do_beta_regression(app_metadata: cli_tools.Metadata,
-                       regression_specification: RegressionSpecification):
+                       regression_specification: RegressionSpecification,
+                       preprocess_only: bool):
     logger.debug('Starting beta regression.')
 
     # init high level objects
@@ -31,6 +32,7 @@ def do_beta_regression(app_metadata: cli_tools.Metadata,
     regression_specification.dump(data_interface.regression_paths.regression_specification)
 
     # build workflow and launch
-    regression_wf = RegressionWorkflow(regression_specification.data.output_root)
-    regression_wf.attach_beta_regression_tasks(n_draws=regression_specification.parameters.n_draws)
-    regression_wf.run()
+    if not preprocess_only:
+        regression_wf = RegressionWorkflow(regression_specification.data.output_root)
+        regression_wf.attach_beta_regression_tasks(n_draws=regression_specification.parameters.n_draws)
+        regression_wf.run()


### PR DESCRIPTION
This PR adds a `--preprocess-only` flag to both stages of the SEIR pipeline that generates the output directory and metadata.  This allows easy testing of the individual tasks since they require an existing output directory to exist already.