### PR TITLE
Add base classes for task templates and workflows to reduce boilerplate

### DIFF
--- a/src/covid_model_seiir_pipeline/forecasting/workflow.py
+++ b/src/covid_model_seiir_pipeline/forecasting/workflow.py
@@ -1,70 +1,40 @@
 from itertools import product
 from typing import List
 
-from jobmon.client import Workflow, BashTask
 from jobmon.client.swarm.executors.base import ExecutorParameters
-from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
 
-from covid_model_seiir_pipeline import utilities
-
-
-class BetaForecastTaskTemplate:
-
-    def __init__(self):
-        self.command_template = (
-            "beta_forecast " +
-            "--draw-id {draw_id} " +
-            "--forecast-version {forecast_version} " +
-            "--scenario {scenario}"
-        )
-        self.params = ExecutorParameters(
-            max_runtime_seconds=1000,
-            m_mem_free='3G',
-            num_cores=1,
-            queue='d.q'
-        )
-
-    @classmethod
-    def get_task_name(cls, draw_id: int, scenario: str) -> str:
-        return f"forecast_{scenario}_{draw_id}"
-
-    def get_task(self, draw_id: int, forecast_version: str, scenario: str):
-        task_name = self.get_task_name(draw_id, scenario)
-        task = BashTask(
-            command=self.command_template.format(draw_id=draw_id,
-                                                 forecast_version=forecast_version,
-                                                 scenario=scenario),
-            name=task_name,
-            executor_parameters=self.params,
-            max_attempts=1
-        )
-        return task
+from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowTemplate
 
 
-class ForecastWorkflow:
 
-    def __init__(self, version: str) -> None:
-        self.version = version
-        self.task_template = BetaForecastTaskTemplate()
+class BetaForecastTaskTemplate(TaskTemplate):
 
-        workflow_args = f'seiir-forecast-{version}'
-        stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
+    task_name_template = "forecast_{scenario}_{draw_id}"
+    command_template = (
+        "beta_forecast " +
+        "--draw-id {draw_id} " +
+        "--forecast-version {forecast_version} " +
+        "--scenario {scenario}"
+    )
+    params = ExecutorParameters(
+        max_runtime_seconds=1000,
+        m_mem_free='3G',
+        num_cores=1,
+        queue='d.q'
+    )
 
-        self.workflow = Workflow(
-            workflow_args=workflow_args,
-            project="proj_covid",
-            stderr=stderr,
-            stdout=stdout,
-            seconds_until_timeout=60*60*24,
-            resume=True
-        )
 
-    def attach_scenario_tasks(self, n_draws: int, scenarios: List[str]):
+class ForecastWorkflow(WorkflowTemplate):
+
+    workflow_name_template = 'seiir-forecast-{version}'
+    task_templates = {'forecast': BetaForecastTaskTemplate}
+
+    def attach_tasks(self, n_draws: int, scenarios: List[str]):
+        forecast_template = self.task_templates['forecast']
         for draw, scenario in product(range(n_draws), scenarios):
-            task = self.task_template.get_task(draw, self.version, scenario)
+            task = forecast_template.get_task(
+                forecast_version=self.version,
+                draw_id=draw,
+                scenario=scenario
+            )
             self.workflow.add_task(task)
-
-    def run(self):
-        execution_status = self.workflow.run()
-        if execution_status != DagExecutionStatus.SUCCEEDED:
-            raise RuntimeError("Workflow failed. Check database or logs for errors")

--- a/src/covid_model_seiir_pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/regression/workflow.py
@@ -1,65 +1,33 @@
-from jobmon.client import Workflow, BashTask
 from jobmon.client.swarm.executors.base import ExecutorParameters
-from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
 
-from covid_model_seiir_pipeline import utilities
+from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowTemplate
 
 
-class BetaRegressionTaskTemplate:
-
-    def __init__(self):
-        self.command_template = (
+class BetaRegressionTaskTemplate(TaskTemplate):
+    task_name_template = "beta_regression_draw_{draw_id}"
+    command_template = (
             "beta_regression " +
             "--draw-id {draw_id} " +
             "--regression-version {regression_version} "
-        )
-        self.params = ExecutorParameters(
-            max_runtime_seconds=3000,
-            m_mem_free='2G',
-            num_cores=1,
-            queue='d.q'
-        )
-
-    @staticmethod
-    def get_task_name(draw_id: int) -> str:
-        return f"regression_{draw_id}"
-
-    def get_task(self, draw_id: int, regression_version: str):
-        task_name = self.get_task_name(draw_id)
-        task = BashTask(
-            command=self.command_template.format(draw_id=draw_id,
-                                                 regression_version=regression_version),
-            name=task_name,
-            executor_parameters=self.params,
-            max_attempts=1
-        )
-        return task
+    )
+    params = ExecutorParameters(
+        max_runtime_seconds=3000,
+        m_mem_free='2G',
+        num_cores=1,
+        queue='d.q'
+    )
 
 
-class RegressionWorkflow:
+class RegressionWorkflow(WorkflowTemplate):
 
-    def __init__(self, version: str):
-        self.version = version
-        self.task_template = BetaRegressionTaskTemplate()
+    workflow_name_template = 'seiir-regression-{version}'
+    task_templates = {'regression': BetaRegressionTaskTemplate}
 
-        workflow_args = f'seiir-regression-{version}'
-        stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
-
-        self.workflow = Workflow(
-            workflow_args=workflow_args,
-            project="proj_covid",
-            stderr=stderr,
-            stdout=stdout,
-            seconds_until_timeout=60*60*24,
-            resume=True
-        )
-
-    def attach_beta_regression_tasks(self, n_draws: int):
+    def attach_tasks(self, n_draws: int):
+        regression_template = self.task_templates['regression']
         for draw_id in range(n_draws):
-            task = self.task_template.get_task(draw_id, self.version)
+            task = regression_template.get_task(
+                regression_version=self.version,
+                draw_id=draw_id
+            )
             self.workflow.add_task(task)
-
-    def run(self):
-        execution_status = self.workflow.run()
-        if execution_status != DagExecutionStatus.SUCCEEDED:
-            raise RuntimeError("Workflow failed. Check database or logs for errors")

--- a/src/covid_model_seiir_pipeline/workflow_template.py
+++ b/src/covid_model_seiir_pipeline/workflow_template.py
@@ -1,0 +1,54 @@
+import abc
+from typing import Dict
+
+from jobmon.client import Workflow, BashTask
+from jobmon.client.swarm.executors.base import ExecutorParameters
+from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
+
+from covid_model_seiir_pipeline import utilities
+
+
+class TaskTemplate:
+
+    task_name_template: str = None
+    command_template: str = None
+    params: ExecutorParameters = None
+
+    @classmethod
+    def get_task(cls, *_, **kwargs) -> BashTask:
+        task = BashTask(
+            command=cls.command_template.format(**kwargs),
+            name=cls.task_name_template.format(**kwargs),
+            executor_parameters=cls.params,
+            max_attempts=1
+        )
+        return task
+
+
+class WorkflowTemplate:
+
+    workflow_name_template: str = None
+    task_templates: Dict[str, TaskTemplate] = None
+
+    def __init__(self, version: str):
+        self.version = version
+        stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
+
+        self.workflow = Workflow(
+            workflow_args=self.workflow_name_template.format(version=version),
+            project="proj_covid",
+            stderr=stderr,
+            stdout=stdout,
+            seconds_until_timeout=60*60*24,
+            resume=True
+        )
+
+    @abc.abstractmethod
+    def attach_tasks(self, *args, **kwargs):
+        pass
+
+    def run(self):
+        execution_status = self.workflow.run()
+        if execution_status != DagExecutionStatus.SUCCEEDED:
+            raise RuntimeError("Workflow failed. Check database or logs for errors")
+


### PR DESCRIPTION
This PR pulls out base classes for the task templates and workflows.  

Context: I'm about to start adding new tasks and maybe a new workflow and wanted to reduce some boiler plate.