### PR TITLE
Collijk/feature/mandate reimposition

### DIFF
--- a/specification_templates/forecast.yaml
+++ b/specification_templates/forecast.yaml
@@ -1,6 +1,6 @@
 data:
-  regression_version: '2020_08_10.02'
-  covariate_version: '2020_08_09.01'
+  regression_version: '2020_08_16.02'
+  covariate_version: '2020_08_16.05'
   output_root: ''
 scenarios:
   worse:
@@ -15,7 +15,7 @@ scenarios:
     theta: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/theta_2020_07_05.01.csv'
     covariates:
       pneumonia: 'reference'
-      mobility: 'lift'
+      mobility: 'reference'
       mask_use: 'reference'
       testing: 'reference'
       air_pollution_pm_2_5: 'reference'
@@ -37,7 +37,7 @@ scenarios:
     theta: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/theta_2020_07_05.01.csv'
     covariates:
       pneumonia: 'reference'
-      mobility: 'lift'
+      mobility: 'reference'
       mask_use: 'reference'
       testing: 'reference'
       air_pollution_pm_2_5: 'reference'
@@ -59,7 +59,7 @@ scenarios:
     theta: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/theta_2020_07_05.01.csv'
     covariates:
       pneumonia: 'reference'
-      mobility: 'lift'
+      mobility: 'reference'
       mask_use: 'best'
       testing: 'reference'
       air_pollution_pm_2_5: 'reference'

--- a/specification_templates/forecast.yaml
+++ b/specification_templates/forecast.yaml
@@ -4,7 +4,8 @@ data:
   output_root: ''
 scenarios:
   worse:
-    algorithm: 'RK45'  # Later also 'mattingly', 'RK45-loop', etc.
+    algorithm: 'normal'
+    solver: 'RK45'
     beta_scaling:
       window_size: 42
       average_over_min: 7
@@ -14,8 +15,52 @@ scenarios:
     theta: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/theta_2020_07_05.01.csv'
     covariates:
       pneumonia: 'reference'
-      mobility: 'reference'
+      mobility: 'lift'
       mask_use: 'reference'
+      testing: 'reference'
+      air_pollution_pm_2_5: 'reference'
+      smoking_prevalence: 'reference'
+      lri_mortality: 'reference'
+      proportion_under_100m: 'reference'
+      proportion_over_2_5k: 'reference'
+  reference:
+    algorithm: 'mandate_reimposition'
+    algorithm_params:
+      death_threshold: 8  # per million
+    solver: 'RK45'
+    beta_scaling:
+      window_size: 42
+      average_over_min: 7
+      average_over_max: 28
+      offset_deaths_lower: 150
+      offset_deaths_upper: 300
+    theta: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/theta_2020_07_05.01.csv'
+    covariates:
+      pneumonia: 'reference'
+      mobility: 'lift'
+      mask_use: 'reference'
+      testing: 'reference'
+      air_pollution_pm_2_5: 'reference'
+      smoking_prevalence: 'reference'
+      lri_mortality: 'reference'
+      proportion_under_100m: 'reference'
+      proportion_over_2_5k: 'reference'
+  best_masks:
+    algorithm: 'mandate_reimposition'
+    algorithm_params:
+      death_threshold: 8  # per million
+    solver: 'RK45'
+    beta_scaling:
+      window_size: 42
+      average_over_min: 7
+      average_over_max: 28
+      offset_deaths_lower: 150
+      offset_deaths_upper: 300
+    theta: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/theta_2020_07_05.01.csv'
+    covariates:
+      pneumonia: 'reference'
+      mobility: 'lift'
+      mask_use: 'best'
       testing: 'reference'
       air_pollution_pm_2_5: 'reference'
       smoking_prevalence: 'reference'

--- a/specification_templates/regression.yaml
+++ b/specification_templates/regression.yaml
@@ -1,6 +1,6 @@
 data:
   infection_version: '2020_08_04.05'
-  covariate_version: '2020_08_09.01'
+  covariate_version: '2020_08_16.02'
   location_set_version_id: ''
   location_set_file: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/location_metadata_762.csv'
   output_root: ''

--- a/src/covid_model_seiir_pipeline/forecasting/data.py
+++ b/src/covid_model_seiir_pipeline/forecasting/data.py
@@ -167,7 +167,7 @@ class ForecastDataInterface:
         if 'date' in info_df.columns:
             info_df['date'] = pd.to_datetime(info_df['date'])
             index_columns.append('date')
-        return info_df.set_inex(index_columns)
+        return info_df.set_index(index_columns)
 
     def load_beta_params(self, draw_id: int) -> Dict[str, float]:
         df = self.regression_marshall.load(key=MKeys.parameter(draw_id=draw_id))

--- a/src/covid_model_seiir_pipeline/forecasting/data.py
+++ b/src/covid_model_seiir_pipeline/forecasting/data.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Union
 
 from loguru import logger
 import pandas as pd
@@ -64,6 +64,15 @@ class ForecastDataInterface:
             location_ids = yaml.full_load(location_file)
         return location_ids
 
+    def load_thetas(self, theta_specification: Union[str, int]) -> pd.Series:
+        if isinstance(theta_specification, str):
+            thetas = pd.read_csv(theta_specification).set_index('location_id')['theta']
+        else:
+            location_ids = self.load_location_ids()
+            thetas = pd.Series({'theta': theta_specification},
+                               index=pd.Index(location_ids, name='location_id'))
+        return thetas
+
     def check_covariates(self, scenarios: Dict[str, ScenarioSpecification]):
         with self.regression_paths.regression_specification.open() as regression_spec_file:
             regression_spec = yaml.full_load(regression_spec_file)
@@ -111,11 +120,12 @@ class ForecastDataInterface:
         return self.regression_marshall.load(MKeys.coefficient(draw_id))
 
     # TODO: inverse is RegressionDataInterface.save_date_file
-    def load_dates_df(self, draw_id: int) -> pd.DataFrame:
+    def load_transition_date(self, draw_id: int) -> pd.Series:
         dates_df = self.regression_marshall.load(key=MKeys.date(draw_id))
         dates_df['start_date'] = pd.to_datetime(dates_df['start_date'])
         dates_df['end_date'] = pd.to_datetime(dates_df['end_date'])
-        return dates_df
+        transition_date = dates_df.set_index('location_id').sort_index()['end_date'].rename('date')
+        return transition_date
 
     # TODO: inverse is RegressionDataInterface.save_regression_betas
     def load_beta_regression(self, draw_id: int) -> pd.DataFrame:
@@ -148,6 +158,16 @@ class ForecastDataInterface:
                 covariate_data.append(self.load_covariate(covariate, covariate_version, location_ids))
         covariate_data = reduce(lambda x, y: x.merge(y, left_index=True, right_index=True), covariate_data)
         return covariate_data.reset_index()
+
+    def load_covariate_info(self, covariate: str, info_type: str, location_ids: List[int]):
+        info_path = self.covariate_paths.get_covariate_info_file(covariate, info_type)
+        info_df = pd.read_csv(info_path)
+        index_columns = ['location_id']
+        info_df = info_df.loc[info_df['location_id'].isin(location_ids), :]
+        if 'date' in info_df.columns:
+            info_df['date'] = pd.to_datetime(info_df['date'])
+            index_columns.append('date')
+        return info_df.set_inex(index_columns)
 
     def load_beta_params(self, draw_id: int) -> Dict[str, float]:
         df = self.regression_marshall.load(key=MKeys.parameter(draw_id=draw_id))

--- a/src/covid_model_seiir_pipeline/forecasting/model.py
+++ b/src/covid_model_seiir_pipeline/forecasting/model.py
@@ -86,9 +86,9 @@ class SeiirModelSpecs:
 class ODERunner:
 
     def __init__(self, solver_name: str, model_specs: SeiirModelSpecs):
-        self.system = CustomizedSEIIR(**asdict(model_specs))
-        if solver_name == "RK4":
-            self.solver = RK4(self.system, model_specs.delta)
+        self.model = CustomizedSEIIR(**asdict(model_specs))
+        if solver_name == "RK45":
+            self.solver = RK4(self.model.system, model_specs.delta)
         else:
             raise NotImplementedError(f"Unknown solver type {solver_name}.")
 
@@ -109,7 +109,7 @@ class ODERunner:
 
         result = pd.DataFrame(
             data=result_array,
-            columns=self.system.components + self.system.params + ['t']
+            columns=self.model.components + self.model.params + ['t']
         )
 
         return result

--- a/src/covid_model_seiir_pipeline/forecasting/model.py
+++ b/src/covid_model_seiir_pipeline/forecasting/model.py
@@ -145,9 +145,9 @@ def run_normal_ode_model_by_location(initial_condition, beta_params, betas, thet
 
 
 def splice_components(components_past, components_forecast, transition_day):
-    shared_columns = ['location_id', 'date', 'S', 'E', 'I1', 'I2', 'R', 'beta']
-    components_past = components_past.reset_index().loc[~transition_day, shared_columns]
-    components_forecast = components_forecast[shared_columns]
+    shared_columns = ['date', 'S', 'E', 'I1', 'I2', 'R', 'beta']
+    components_past = components_past.loc[~transition_day, shared_columns].reset_index()
+    components_forecast = components_forecast[['location_id'] + shared_columns]
     components = (pd.concat([components_past, components_forecast])
                   .sort_values(['location_id', 'date'])
                   .set_index(['location_id']))

--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -20,12 +20,15 @@ class ForecastData:
 @dataclass
 class ScenarioSpecification:
     """Forecasting specification for a scenario."""
-    ALLOWED_ALGORITHMS = ('RK45',)
+    ALLOWED_ALGORITHMS = ('normal', 'mandate_reimposition')
+    ALLOWED_SOLVERS = ('RK45',)
     BETA_SCALING_KEYS = {'window_size', 'average_over_min', 'average_over_max',
                          'offset_deaths_lower', 'offset_deaths_upper'}
 
     name: str = field(default='dummy_scenario')
-    algorithm: str = field(default='RK45')
+    algorithm: str = field(default='normal')
+    algorithm_params: Dict = field(default_factory=dict)
+    solver: str = field(default='RK45')
     beta_scaling: Dict[str, int] = field(default_factory=dict)
     theta: Union[str, int] = field(default=0)
     covariates: Dict[str, str] = field(default_factory=dict)
@@ -34,6 +37,10 @@ class ScenarioSpecification:
         if self.algorithm not in self.ALLOWED_ALGORITHMS:
             raise ValueError(f'Unknown algorithm {self.algorithm} in scenario {self.name}. '
                              f'Allowed algorithms are {self.ALLOWED_ALGORITHMS}.')
+
+        if self.solver not in self.ALLOWED_SOLVERS:
+            raise ValueError(f'Unknown solver {self.solver} in scenario {self.name}. '
+                             f'Allowed solvers are {self.ALLOWED_SOLVERS}.')
 
         bad_scaling_keys = set(self.beta_scaling).difference(self.BETA_SCALING_KEYS)
         if bad_scaling_keys:

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -8,13 +8,14 @@ import pandas as pd
 import numpy as np
 
 from covid_model_seiir_pipeline import static_vars
-from covid_model_seiir_pipeline.math import compute_beta_hat
+
 from covid_model_seiir_pipeline.forecasting import model
 from covid_model_seiir_pipeline.forecasting.specification import ForecastSpecification
 from covid_model_seiir_pipeline.forecasting.data import ForecastDataInterface
 
 
 log = logging.getLogger(__name__)
+
 
 
 def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
@@ -26,99 +27,118 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     data_interface = ForecastDataInterface.from_specification(forecast_spec)
 
     location_ids = data_interface.load_location_ids()
-    if isinstance(scenario_spec.theta, str):
-        thetas = pd.read_csv(scenario_spec.theta).set_index('location_id')['theta']
-    else:
-        thetas = pd.Series({'theta': scenario_spec.theta},
-                           index=pd.Index(location_ids, name='location_id'))
-
-    # Contains the start and end date for the data that was fit.
-    # End dates vary based on how many days of leading indicator data
-    # we use from the deaths model.
-    dates_df = data_interface.load_dates_df(draw_id)
+    # Thetas are a parameter generated from assumption or OOS predictive
+    # validity testing to curtail some of the bad behavior of the model.
+    thetas = data_interface.load_thetas(scenario_spec.theta)
+    # Grab the last day of data in the model by location id.  This will
+    # correspond to the initial condition for the projection.
+    transition_date = data_interface.load_transition_date(draw_id)
     # we just want a map between location id and day we transition to
     # prediction.
-    transition_date = dates_df.set_index('location_id').sort_index()['end_date'].rename('date')
 
     # We'll use the beta and SEIR compartments from this data set to get
     # the ODE initial condition.
     beta_regression_df = data_interface.load_beta_regression(draw_id).set_index('location_id').sort_index()
+    past_components = beta_regression_df[['date', 'beta'] + static_vars.SEIIR_COMPARTMENTS]
+
+    # Select out the initial condition using the day of transition.
+    transition_day = past_components['date'] == transition_date.loc[past_components.index]
+    initial_condition = past_components.loc[transition_day, static_vars.SEIIR_COMPARTMENTS]
 
     # Covariates and coefficients, and scaling parameters are
     # used to compute beta hat in the future.
     covariates = data_interface.load_covariates(scenario_spec, location_ids)
     coefficients = data_interface.load_regression_coefficients(draw_id)
-    beta_scales = data_interface.load_beta_scales(scenario=scenario_name, draw_id=draw_id)
-
-    # We'll use the same params in the ODE forecast as we did in the fit.
-    beta_params = data_interface.load_beta_params(draw_id=draw_id)
-
-    # Modeling starts
-
     # Grab the projection of the covariates into the future, keeping the
     # day of transition from past model to future model.
     covariates = covariates.set_index('location_id').sort_index()
     the_future = covariates['date'] >= transition_date.loc[covariates.index]
     covariate_pred = covariates.loc[the_future].reset_index()
 
-    log_beta_hat = compute_beta_hat(covariate_pred, coefficients)
-    beta_hat = np.exp(log_beta_hat).rename('beta_pred').reset_index()
+    beta_scales = data_interface.load_beta_scales(scenario=scenario_name, draw_id=draw_id)
 
-    # Rescale the predictions of beta based on the residuals from the
-    # regression.
-    betas = model.beta_shift(beta_hat, beta_scales).set_index('location_id')
+    # We'll use the same params in the ODE forecast as we did in the fit.
+    beta_params = data_interface.load_beta_params(draw_id=draw_id)
 
-    transition_day = beta_regression_df['date'] == transition_date.loc[beta_regression_df.index]
-    compartments = ['S', 'E', 'I1', 'I2', 'R']
-    initial_condition = beta_regression_df.loc[transition_day, compartments]
-
-    forecasts = []
-    for location_id in location_ids:
-        log.info(f"On location id {location_id}")
-        init_cond = initial_condition.loc[location_id].values
-        total_population = init_cond.sum()
-
-        model_specs = model.SeiirModelSpecs(
-            alpha=beta_params['alpha'],
-            sigma=beta_params['sigma'],
-            gamma1=beta_params['gamma1'],
-            gamma2=beta_params['gamma2'],
-            N=total_population,
-        )
-        ode_runner = model.ODERunner(model_specs, init_cond)
-
-        loc_betas = betas.loc[location_id].sort_values('date')
-        loc_days = loc_betas['date']
-        loc_times = np.array((loc_days - loc_days.min()).dt.days)
-        loc_betas = loc_betas['beta_pred'].values
-        loc_thetas = np.repeat(thetas.get(location_id, default=0), loc_betas.size)
-
-        forecasted_components = ode_runner.get_solution(loc_times, loc_betas, loc_thetas)
-        forecasted_components['date'] = loc_days.values
-        forecasted_components['location_id'] = location_id
-        forecasts.append(forecasted_components)
-
-    forecasts = pd.concat(forecasts)
-    # Concat past with future
-    shared_columns = ['date', 'S', 'E', 'I1', 'I2', 'R', 'beta']
-    components = (pd.concat([beta_regression_df.loc[~transition_day, shared_columns].reset_index(),
-                             forecasts[['location_id'] + shared_columns]])
-                    .sort_values(['location_id', 'date'])
-                    .set_index(['location_id']))
-    components['theta'] = thetas.reindex(components.index).fillna(0)
-    data_interface.save_components(components.reset_index(), scenario_name, draw_id)
-
+    # We'll need this to compute deaths and to splice with the forecasts.
     infection_data = data_interface.load_infection_data(draw_id)
 
-    observed_infections, modeled_infections = model.compute_infections(infection_data, components)
-    infections = observed_infections.combine_first(modeled_infections)['cases_draw'].rename('infections')
+    # Modeling starts
 
-    observed_deaths, modeled_deaths = model.compute_deaths(infection_data, modeled_infections)
-    deaths = observed_deaths.combine_first(modeled_deaths).rename(columns={'deaths_draw': 'deaths'})
+    betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
+    future_components = model.run_normal_ode_model_by_location(initial_condition, beta_params, betas, thetas,
+                                                               location_ids, scenario_spec.solver)
+    components = model.splice_components(past_components, future_components, transition_date)
+    components['theta'] = thetas.reindex(components.index).fillna(0)
+    infections, deaths, r_effective = model.compute_output_metrics(infection_data, components, beta_params)
 
-    r_effective = model.compute_effective_r(infection_data, components, beta_params)
+    if scenario_spec.algorithm == 'mandate_reimposition':
+        min_wait = pd.Timedelta(days=7 * 2)
+        days_on = pd.Timedelta(days=7 * 6)
 
+        population = (components[static_vars.SEIIR_COMPARTMENTS]
+                      .sum(axis=1)
+                      .rename('population')
+                      .groupby('location_id')
+                      .max())
+        death_rate = deaths.merge(population, on='location_id')
+        death_rate['death_rate'] = death_rate['deaths'] / death_rate['population']
+        mobility = covariates['mobility']
+        percent_mandates = data_interface.load_covariate_info('mobility', 'mandate_lift', location_ids)
+        mandate_effect = data_interface.load_covariate_info('mobility', 'effect', location_ids)
+        reimposition_threshold = scenario_spec.algorithm_params['death_threshold']
+
+        # compute reimposition dates
+        over_threshold = death_rate['death_rate'] > reimposition_threshold
+        projected = death_rate['observed'] == 0
+        reimposition_date = death_rate[over_threshold & projected].groupy('location_id')['date'].min()
+        min_reimposition_date = (transition_date + min_wait).loc[reimposition_date.index]
+        reimposition_date = (reimposition_date
+                             .where(reimposition_date >= min_reimposition_date, min_reimposition_date)
+                             .rename('reimposition_date'))
+
+        # compute mobility lower bound
+        min_observed_mobility = mobility.groupby('location_id')['mobility'].min().rename('min_mobility')
+        max_mandate_mobility = mandate_effect.sum(axis=1).rename('min_mobility')
+        mobility_lower_bound = min_observed_mobility.where(min_observed_mobility <= max_mandate_mobility,
+                                                           max_mandate_mobility)
+
+        mobility_reference = (mobility
+                              .merge(reimposition_date, how='left', on='location_id')
+                              .merge(mobility_lower_bound, how='left', on='location_id'))
+
+        reimposes = mobility_reference['reimposition_date'].notnull()
+        dates_on = ((mobility_reference['reimposition_date'] <= mobility_reference['date'])
+                    & mobility_reference['date'] <= mobility_reference['reimposition_date'] + min_wait)
+        mobility_reference['mobility_explosion'] = mobility_reference['min_mobility'].where(reimposes & dates_on, np.nan)
+
+        rampup = pd.merge(reimposition_date, percent_mandates, on='location_id', how='left')
+        rampup['rampup'] = rampup.groupby('location_id')['percent'].apply(lambda x: x / x.max())
+        rampup['first_date'] = rampup.groupby('location_id')['date'].transform('min')
+        rampup['diff_date'] = rampup['reimposition_date'] - rampup['first_date']
+        rampup['date'] = rampup['date'] + rampup['diff_date'] + days_on
+
+        mobility_reference = mobility_reference.merge(rampup, how='left', on=['location_id', 'date'])
+        post_explosion = mobility_reference['mobility_explosion'].isnull() & mobility_reference['rampup'].notnull()
+        mobility_reference['mobility_explosion'] = mobility_reference['mobility_explosion'].where(
+            ~post_explosion,
+            mobility_reference['min_mobility'] * mobility_reference['rampup']
+        )
+        mobility_reference['mobility'] = mobility_reference[['mobility', 'mobility_explosion']].min(axis=1)
+
+        covariate_pred['mobility'] = mobility_reference['mobility']
+
+        betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
+        future_components = model.run_normal_ode_model_by_location(initial_condition, beta_params, betas, thetas,
+                                                                   location_ids, scenario_spec.solver)
+        components = model.splice_components(past_components, future_components, transition_date)
+        components['theta'] = thetas.reindex(components.index).fillna(0)
+        infections, deaths, r_effective = model.compute_output_metrics(infection_data, components, beta_params)
+
+    components = components.reset_index()
     outputs = pd.concat([infections, deaths, r_effective], axis=1).dropna().reset_index()
+
+    data_interface.save_components(components, scenario_name, draw_id)
     data_interface.save_raw_outputs(outputs, scenario_name, draw_id)
 
 

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -19,7 +19,6 @@ log = logging.getLogger(__name__)
 
 def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     log.info("Initiating SEIIR beta forecasting.")
-    import pdb; pdb.set_trace()
     forecast_spec: ForecastSpecification = ForecastSpecification.from_path(
         Path(forecast_version) / static_vars.FORECAST_SPECIFICATION_FILE
     )
@@ -62,14 +61,14 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     infection_data = data_interface.load_infection_data(draw_id)
 
     # Modeling starts
-    import pdb; pdb.set_trace()
     betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
     future_components = model.run_normal_ode_model_by_location(initial_condition, beta_params, betas, thetas,
                                                                location_ids, scenario_spec.solver)
-    components = model.splice_components(past_components, future_components, transition_date)
+    import pdb; pdb.set_trace()
+    components = model.splice_components(past_components, future_components, transition_day)
     components['theta'] = thetas.reindex(components.index).fillna(0)
     infections, deaths, r_effective = model.compute_output_metrics(infection_data, components, beta_params)
-    
+
     import pdb; pdb.set_trace()
     if scenario_spec.algorithm == 'mandate_reimposition':
         min_wait = pd.Timedelta(days=7 * 2)

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     log.info("Initiating SEIIR beta forecasting.")
+    import pdb; pdb.set_trace()
     forecast_spec: ForecastSpecification = ForecastSpecification.from_path(
         Path(forecast_version) / static_vars.FORECAST_SPECIFICATION_FILE
     )
@@ -61,14 +62,15 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     infection_data = data_interface.load_infection_data(draw_id)
 
     # Modeling starts
-
+    import pdb; pdb.set_trace()
     betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
     future_components = model.run_normal_ode_model_by_location(initial_condition, beta_params, betas, thetas,
                                                                location_ids, scenario_spec.solver)
     components = model.splice_components(past_components, future_components, transition_date)
     components['theta'] = thetas.reindex(components.index).fillna(0)
     infections, deaths, r_effective = model.compute_output_metrics(infection_data, components, beta_params)
-
+    
+    import pdb; pdb.set_trace()
     if scenario_spec.algorithm == 'mandate_reimposition':
         min_wait = pd.Timedelta(days=7 * 2)
         days_on = pd.Timedelta(days=7 * 6)

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -17,7 +17,6 @@ from covid_model_seiir_pipeline.forecasting.data import ForecastDataInterface
 log = logging.getLogger(__name__)
 
 
-
 def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     log.info("Initiating SEIIR beta forecasting.")
     forecast_spec: ForecastSpecification = ForecastSpecification.from_path(
@@ -33,8 +32,6 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     # Grab the last day of data in the model by location id.  This will
     # correspond to the initial condition for the projection.
     transition_date = data_interface.load_transition_date(draw_id)
-    # we just want a map between location id and day we transition to
-    # prediction.
 
     # We'll use the beta and SEIR compartments from this data set to get
     # the ODE initial condition.

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_residual_scaling.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_residual_scaling.py
@@ -152,8 +152,7 @@ def compute_initial_beta_scaling_parameters_by_draw(draw_id: int,
     # number of predicted days from the elastispliner in the ODE fit
     # and the random draw of lag between infection and death from the
     # infectionator. Don't compute, let's look it up.
-    dates_df = data_interface.load_dates_df(draw_id)
-    transition_date = dates_df.set_index('location_id').sort_index()['end_date'].rename('date')
+    transition_date = data_interface.load_transition_date(draw_id)
 
     beta_regression_df = data_interface.load_beta_regression(draw_id)
     beta_regression_df = beta_regression_df.set_index('location_id').sort_index()

--- a/src/covid_model_seiir_pipeline/forecasting/workflow.py
+++ b/src/covid_model_seiir_pipeline/forecasting/workflow.py
@@ -6,7 +6,7 @@ from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowT
 
 # TODO: Extract these into specification, maybe.  At least allow overrides
 #    for the queue from the command line.
-FORECAST_RUNTIME = 1000
+FORECAST_RUNTIME = 2000
 FORECAST_MEMORY = '5G'
 POSTPROCESS_MEMORY = '50G'
 FORECAST_CORES = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def dates():
         [526, '2020-03-08', '2020-05-05'],
         [533, '2020-02-23', '2020-05-05'],
         [537, '2020-02-26', '2020-05-05'],
-    ], columns=['loc_id', 'start_date', 'end_date'])
+    ], columns=['location_id', 'start_date', 'end_date'])
 
 
 @pytest.fixture

--- a/tests/forecasting/test_data.py
+++ b/tests/forecasting/test_data.py
@@ -50,14 +50,16 @@ class TestForecastDataInterfaceIO:
         # Step 2: load files as they would be loaded in forecast
         loaded_coefficients = fdi.load_regression_coefficients(draw_id=4)
         loaded_parameters = fdi.load_beta_params(draw_id=4)
-        loaded_dates = fdi.load_dates_df(draw_id=4)
+        loaded_transition_dates = fdi.load_transition_date(draw_id=4)
         loaded_regression_beta = fdi.load_beta_regression(draw_id=4)
         loaded_location_data = fdi.load_infection_data(draw_id=4)
 
         # Step 3: test files
         pandas.testing.assert_frame_equal(coefficients, loaded_coefficients)
         # some load methods do pandas.to_datetime conversion on columns
-        assert_equal_after_date_conversion(dates, loaded_dates, date_cols=['start_date', 'end_date'])
+        transition_dates = dates.set_index('location_id').sort_index()['end_date'].rename('date').reset_index()
+        loaded_transition_dates = loaded_transition_dates.reset_index()
+        assert_equal_after_date_conversion(transition_dates, loaded_transition_dates, date_cols=['date'])
         assert_equal_after_date_conversion(regression_beta, loaded_regression_beta, date_cols=['date'])
         assert_equal_after_date_conversion(location_data, loaded_location_data, date_cols=['date'])
 

--- a/tests/forecasting/test_ode_runner.py
+++ b/tests/forecasting/test_ode_runner.py
@@ -17,6 +17,7 @@ def test_ode_runner():
 
     t = np.arange(0, 31, 1)
     beta = 2*np.exp(-0.01*t)
-    ode_runner = ODERunner(specs, init_cond)
-    result = ode_runner.get_solution(t, beta)
+    theta = np.zeros_like(beta)
+    ode_runner = ODERunner('RK45', specs)
+    result = ode_runner.get_solution(init_cond, t, beta, theta)
     print("Okay!")


### PR DESCRIPTION
This PR implements the mandate reimposition algorithm, removing the external loop from the production pipeline.  

This is very much a "make it work" PR, which it does.  It needs a pass to turn stuff into functions, build abstractions, and allow a more generic algorithm specification for the forecast, but postprocessing updates come first. 