### PR TITLE
Collijk/feature/multiple mandate reimposition

### DIFF
--- a/src/covid_model_seiir_pipeline/forecasting/model.py
+++ b/src/covid_model_seiir_pipeline/forecasting/model.py
@@ -277,15 +277,15 @@ def compute_effective_r(infection_data: pd.DataFrame, components: pd.DataFrame,
 
 
 def compute_reimposition_date(deaths, population, reimposition_threshold,
-                              min_wait, last_reimposition_end_date=None) -> pd.Series:
+                              min_wait, last_reimposition_end_date) -> pd.Series:
     death_rate = deaths.reset_index(level='date').merge(population, on='location_id')
     death_rate['death_rate'] = death_rate['deaths'] / death_rate['population']
 
     projected = death_rate['observed'] == 0
     last_observed_date = death_rate[~projected].groupby('location_id')['date'].max()
     min_reimposition_date = (last_observed_date + min_wait)
-    if last_reimposition_end_date is not None:
-        min_reimposition_date.loc[last_reimposition_end_date.index] = last_reimposition_end_date + min_wait
+    previously_implemented = last_reimposition_end_date[last_reimposition_end_date.notnull()].index
+    min_reimposition_date.loc[previously_implemented] = last_reimposition_end_date.loc[previously_implemented] + min_wait
 
     after_min_reimposition_date = death_rate['date'] >= min_reimposition_date.loc[death_rate.index]
     over_threshold = death_rate['death_rate'] > reimposition_threshold

--- a/src/covid_model_seiir_pipeline/forecasting/model.py
+++ b/src/covid_model_seiir_pipeline/forecasting/model.py
@@ -274,3 +274,71 @@ def compute_effective_r(infection_data: pd.DataFrame, components: pd.DataFrame,
     r_controlled = beta * alpha / avg_gamma * (i1 + i2) ** (alpha - 1)
     r_effective = (r_controlled * s / n).rename('r_effective')
     return r_effective
+
+
+def compute_reimposition_date(deaths, population, reimposition_threshold, min_wait) -> pd.Series:
+    death_rate = deaths.reset_index(level='date').merge(population, on='location_id')
+    death_rate['death_rate'] = death_rate['deaths'] / death_rate['population']
+
+    over_threshold = death_rate['death_rate'] > reimposition_threshold
+    projected = death_rate['observed'] == 0
+    reimposition_date = death_rate[over_threshold & projected].groupby('location_id')['date'].min()
+    last_observed_date = death_rate[~projected].groupby('location_id')['date'].max()
+    min_reimposition_date = (last_observed_date + min_wait).loc[reimposition_date.index]
+    reimposition_date = (reimposition_date
+                         .where(reimposition_date >= min_reimposition_date, min_reimposition_date)
+                         .rename('reimposition_date'))
+    return reimposition_date
+
+
+def compute_mobility_lower_bound(mobility: pd.DataFrame, mandate_effect: pd.DataFrame) -> pd.Series:
+    min_observed_mobility = mobility.groupby('location_id').min().rename('min_mobility')
+    max_mandate_mobility = mandate_effect.sum(axis=1).rename('min_mobility').reindex(min_observed_mobility.index,
+                                                                                     fill_value=100)
+    mobility_lower_bound = min_observed_mobility.where(min_observed_mobility <= max_mandate_mobility,
+                                                       max_mandate_mobility)
+    return mobility_lower_bound
+
+
+def compute_rampup(reimposition_date: pd.Series,
+                   percent_mandates: pd.DataFrame,
+                   days_on: pd.Timedelta) -> pd.DataFrame:
+    rampup = pd.merge(reimposition_date, percent_mandates.reset_index(level='date'), on='location_id', how='left')
+    rampup['rampup'] = rampup.groupby('location_id')['percent'].apply(lambda x: x / x.max())
+    rampup['first_date'] = rampup.groupby('location_id')['date'].transform('min')
+    rampup['diff_date'] = rampup['reimposition_date'] - rampup['first_date']
+    rampup['date'] = rampup['date'] + rampup['diff_date'] + days_on
+    rampup = rampup.reset_index()[['location_id', 'date', 'rampup']]
+    return rampup
+
+
+def compute_new_mobility(old_mobility: pd.Series,
+                         reimposition_date: pd.Series,
+                         mobility_lower_bound: pd.Series,
+                         percent_mandates: pd.DataFrame,
+                         min_wait: pd.Timedelta,
+                         days_on: pd.Timedelta) -> pd.Series:
+    mobility = pd.merge(old_mobility.reset_index(level='date'), reimposition_date, how='left', on='location_id')
+    mobility = mobility.merge(mobility_lower_bound, how='left', on='location_id')
+
+    reimposes = mobility['reimposition_date'].notnull()
+    dates_on = ((mobility['reimposition_date'] <= mobility['date'])
+                & (mobility['date'] <= mobility['reimposition_date'] + min_wait))
+    mobility['mobility_explosion'] = mobility['min_mobility'].where(reimposes & dates_on, np.nan)
+
+    rampup = compute_rampup(reimposition_date, percent_mandates, days_on)
+
+    mobility = mobility.merge(rampup, how='left', on=['location_id', 'date'])
+    post_reimplementation = ~(mobility['mobility_explosion'].isnull() & mobility['rampup'].notnull())
+    mobility['mobility_explosion'] = mobility['mobility_explosion'].where(
+        post_reimplementation,
+        mobility['min_mobility'] * mobility['rampup']
+    )
+
+    idx_columns = ['location_id', 'date']
+    mobility = (mobility[idx_columns + ['mobility', 'mobility_explosion']]
+                .set_index(idx_columns)
+                .sort_index()
+                .min(axis=1))
+    return mobility
+

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -152,7 +152,7 @@ def parse_arguments(argstr: Optional[str] = None) -> Namespace:
 
 
 def main():
-    configure_logging_to_terminal(1)
+    configure_logging_to_terminal(verbose=1)  # Debug level
     args = parse_arguments()
     run_beta_forecast(draw_id=args.draw_id,
                       forecast_version=args.forecast_version,

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -89,6 +89,7 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
         reimposition_count = 0
         reimposition_dates = {}
         reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold, min_wait)
+        last_reimposition_end_date = pd.Series(pd.NaT, index=population.index)
 
         while len(reimposition_date):  # any place reimposes mandates.
             logger.info(f'On mandate reimposition {reimposition_count + 1}. {len(reimposition_date)} locations '
@@ -116,7 +117,7 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
 
             reimposition_count += 1
             reimposition_dates[reimposition_count] = reimposition_date
-            last_reimposition_end_date = reimposition_date + days_on
+            last_reimposition_end_date.loc[reimposition_date.index] = reimposition_date + days_on
             reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold,
                                                                 min_wait, last_reimposition_end_date)
 

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -102,7 +102,8 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
 
             covariates = covariates.reset_index().set_index(['location_id', 'date'])
             covariates['mobility'] = new_mobility
-            covariate_pred = covariates.reset_index(level='date').loc[the_future].reset_index()
+            covariates = covariates.reset_index(level='date')
+            covariate_pred = covariates.loc[the_future].reset_index()
 
             logger.info('Forecasting beta and components.')
             betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -88,8 +88,9 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
 
         reimposition_count = 0
         reimposition_dates = {}
-        reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold, min_wait)
         last_reimposition_end_date = pd.Series(pd.NaT, index=population.index)
+        reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold,
+                                                            min_wait, last_reimposition_end_date)
 
         while len(reimposition_date):  # any place reimposes mandates.
             logger.info(f'On mandate reimposition {reimposition_count + 1}. {len(reimposition_date)} locations '

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -73,68 +73,43 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     if scenario_spec.algorithm == 'mandate_reimposition':
         min_wait = pd.Timedelta(days=scenario_spec.algorithm_params['minimum_delay'])
         days_on = pd.Timedelta(days=static_vars.DAYS_PER_WEEK * scenario_spec.algorithm_params['reimposition_duration'])
+        reimposition_threshold = scenario_spec.algorithm_params['death_threshold'] / 1e6
 
         population = (components[static_vars.SEIIR_COMPARTMENTS]
                       .sum(axis=1)
                       .rename('population')
                       .groupby('location_id')
                       .max())
-        death_rate = deaths.reset_index(level='date').merge(population, on='location_id')
-        death_rate['death_rate'] = death_rate['deaths'] / death_rate['population']
-        mobility = covariates[['date', 'mobility']].reset_index().set_index(['location_id', 'date'])['mobility']
+
         percent_mandates = data_interface.load_covariate_info('mobility', 'mandate_lift', location_ids)
         mandate_effect = data_interface.load_covariate_info('mobility', 'effect', location_ids)
-        reimposition_threshold = scenario_spec.algorithm_params['death_threshold'] / 1e6
 
-        # compute reimposition dates
-        over_threshold = death_rate['death_rate'] > reimposition_threshold
-        projected = death_rate['observed'] == 0
-        reimposition_date = death_rate[over_threshold & projected].groupby('location_id')['date'].min()
-        last_observed_date = death_rate[~projected].groupby('location_id')['date'].max()
-        min_reimposition_date = (last_observed_date + min_wait).loc[reimposition_date.index]
-        reimposition_date = (reimposition_date
-                             .where(reimposition_date >= min_reimposition_date, min_reimposition_date)
-                             .rename('reimposition_date'))
+        reimposition_count = 0
+        reimposition_dates = {}
+        reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold, min_wait)
 
-        # compute mobility lower bound
-        min_observed_mobility = mobility.groupby('location_id').min().rename('min_mobility')
-        max_mandate_mobility = mandate_effect.sum(axis=1).rename('min_mobility').reindex(min_observed_mobility.index, fill_value=100)
-        mobility_lower_bound = min_observed_mobility.where(min_observed_mobility <= max_mandate_mobility,
-                                                           max_mandate_mobility)
+        while len(reimposition_date):  # any place reimposes mandates.
+            mobility = covariates[['date', 'mobility']].reset_index().set_index(['location_id', 'date'])['mobility']
+            mobility_lower_bound = model.compute_mobility_lower_bound(mobility, mandate_effect)
 
-        mobility_reference = pd.merge(mobility.reset_index(level='date'), reimposition_date, how='left', on='location_id')
-        mobility_reference = mobility_reference.merge(mobility_lower_bound, how='left', on='location_id')
+            new_mobility = model.compute_new_mobility(mobility, reimposition_date,
+                                                      mobility_lower_bound, percent_mandates,
+                                                      min_wait, days_on)
 
-        reimposes = mobility_reference['reimposition_date'].notnull()
-        dates_on = ((mobility_reference['reimposition_date'] <= mobility_reference['date'])
-                    & (mobility_reference['date'] <= mobility_reference['reimposition_date'] + min_wait))
-        mobility_reference['mobility_explosion'] = mobility_reference['min_mobility'].where(reimposes & dates_on, np.nan)
+            covariates = covariates.reset_index().set_index(['location_id', 'date'])
+            covariates['mobility'] = new_mobility
+            covariate_pred = covariates.reset_index(level='date').loc[the_future].reset_index()
 
-        rampup = pd.merge(reimposition_date, percent_mandates.reset_index(level='date'), on='location_id', how='left')
-        rampup['rampup'] = rampup.groupby('location_id')['percent'].apply(lambda x: x / x.max())
-        rampup['first_date'] = rampup.groupby('location_id')['date'].transform('min')
-        rampup['diff_date'] = rampup['reimposition_date'] - rampup['first_date']
-        rampup['date'] = rampup['date'] + rampup['diff_date'] + days_on
-        rampup = rampup.reset_index()[['location_id', 'date', 'rampup']]
+            betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
+            future_components = model.run_normal_ode_model_by_location(initial_condition, beta_params, betas, thetas,
+                                                                       location_ids, scenario_spec.solver)
+            components = model.splice_components(past_components, future_components)
+            components['theta'] = thetas.reindex(components.index).fillna(0)
+            infections, deaths, r_effective = model.compute_output_metrics(infection_data, components, beta_params)
 
-        mobility_reference = mobility_reference.merge(rampup, how='left', on=['location_id', 'date'])
-        post_reimplementation = ~(mobility_reference['mobility_explosion'].isnull() & mobility_reference['rampup'].notnull())
-        mobility_reference['mobility_explosion'] = mobility_reference['mobility_explosion'].where(
-            post_reimplementation,
-            mobility_reference['min_mobility'] * mobility_reference['rampup']
-        )
-
-        mobility_reference = mobility_reference[['location_id', 'date', 'mobility', 'mobility_explosion']].set_index(['location_id', 'date']).min(axis=1).sort_index()
-        covariates = covariates.reset_index().set_index(['location_id', 'date'])
-        covariates['mobility'] = mobility_reference
-        covariate_pred = covariates.reset_index(level='date').loc[the_future].reset_index()
-
-        betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
-        future_components = model.run_normal_ode_model_by_location(initial_condition, beta_params, betas, thetas,
-                                                                   location_ids, scenario_spec.solver)
-        components = model.splice_components(past_components, future_components)
-        components['theta'] = thetas.reindex(components.index).fillna(0)
-        infections, deaths, r_effective = model.compute_output_metrics(infection_data, components, beta_params)
+            reimposition_count += 1
+            reimposition_dates[reimposition_count] = reimposition_date
+            reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold, min_wait)
 
     components = components.reset_index()
     covariates = covariates.reset_index()

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -116,7 +116,9 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
 
             reimposition_count += 1
             reimposition_dates[reimposition_count] = reimposition_date
-            reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold, min_wait)
+            last_reimposition_end_date = reimposition_date + days_on
+            reimposition_date = model.compute_reimposition_date(deaths, population, reimposition_threshold,
+                                                                min_wait, last_reimposition_end_date)
 
     logger.info('Writing outputs.')
     components = components.reset_index()

--- a/src/covid_model_seiir_pipeline/forecasting/task/postprocessing.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/postprocessing.py
@@ -231,10 +231,10 @@ def postprocess_covariate(data_interface: ForecastDataInterface,
 
     logger.info(f'Saving data for {covariate}.')
     if covariate_config.draw_level:
-        data_interface.save_output_draws(covariate_data.reset_index(), scenario_name, covariate)
+        data_interface.save_output_draws(covariate_data.reset_index(), scenario_name, covariate_config.label)
 
     summarized_data = pp.summarize(covariate_data)
-    data_interface.save_output_summaries(summarized_data.reset_index(), scenario_name, covariate)
+    data_interface.save_output_summaries(summarized_data.reset_index(), scenario_name, covariate_config.label)
 
 
 def postprocess_miscellaneous(data_interface: ForecastDataInterface,
@@ -245,7 +245,8 @@ def postprocess_miscellaneous(data_interface: ForecastDataInterface,
 
     logger.info(f'Saving {measure} data.')
     if miscellaneous_config.is_table:
-        data_interface.save_output_miscellaneous(miscellaneous_data.reset_index(), scenario_name, measure)
+        data_interface.save_output_miscellaneous(miscellaneous_data.reset_index(), scenario_name,
+                                                 miscellaneous_config.label)
     else:
         # FIXME: yuck
         miscellaneous_dir = data_interface.forecast_paths.scenario_paths[scenario_name].output_miscellaneous
@@ -295,7 +296,7 @@ def parse_arguments(argstr: Optional[str] = None) -> Namespace:
 
 
 def main():
-    configure_logging_to_terminal(1)
+    configure_logging_to_terminal(verbose=1)  # Debug level
     args = parse_arguments()
     run_seir_postprocessing(forecast_version=args.forecast_version,
                             scenario_name=args.scenario_name,


### PR DESCRIPTION
This expands the mandate reimposition loop to run until all locations are below the death threshold until the end of the forecast period.  This takes a thing that used to cost me 10-12 hours and makes it happen in about 10 minutes.  