### PR TITLE
Allow marshalls to overwrite data with optional argument

### DIFF
--- a/src/covid_model_seiir_pipeline/forecasting/data.py
+++ b/src/covid_model_seiir_pipeline/forecasting/data.py
@@ -199,8 +199,10 @@ class ForecastDataInterface:
             index_columns.append('date')
         return info_df.set_index(index_columns)
 
-    def save_raw_covariates(self, covariates: pd.DataFrame, scenario: str, draw_id: int):
-        self.forecast_marshall.dump(covariates, key=MKeys.forecast_raw_covariates(scenario=scenario, draw_id=draw_id))
+    def save_raw_covariates(self, covariates: pd.DataFrame, scenario: str, draw_id: int, strict: bool):
+        self.forecast_marshall.dump(covariates,
+                                    key=MKeys.forecast_raw_covariates(scenario=scenario, draw_id=draw_id),
+                                    strict=strict)
 
     def load_raw_covariates(self, scenario: str, draw_id: int):
         covariates = self.forecast_marshall.load(key=MKeys.forecast_raw_covariates(scenario=scenario, draw_id=draw_id))
@@ -211,8 +213,8 @@ class ForecastDataInterface:
         df = self.regression_marshall.load(key=MKeys.parameter(draw_id=draw_id))
         return df.set_index('params')['values'].to_dict()
 
-    def save_components(self, forecasts: pd.DataFrame, scenario: str, draw_id: int):
-        self.forecast_marshall.dump(forecasts, key=MKeys.components(scenario=scenario, draw_id=draw_id))
+    def save_components(self, forecasts: pd.DataFrame, scenario: str, draw_id: int, strict: bool):
+        self.forecast_marshall.dump(forecasts, key=MKeys.components(scenario=scenario, draw_id=draw_id), strict=strict)
 
     def load_components(self, scenario: str, draw_id: int) -> pd.DataFrame:
         components = self.forecast_marshall.load(key=MKeys.components(scenario=scenario, draw_id=draw_id))
@@ -225,8 +227,10 @@ class ForecastDataInterface:
     def load_beta_scales(self, scenario: str, draw_id: int):
         return self.forecast_marshall.load(MKeys.beta_scales(scenario=scenario, draw_id=draw_id))
 
-    def save_raw_outputs(self, raw_outputs: pd.DataFrame, scenario: str, draw_id: int):
-        self.forecast_marshall.dump(raw_outputs, key=MKeys.forecast_raw_outputs(scenario=scenario, draw_id=draw_id))
+    def save_raw_outputs(self, raw_outputs: pd.DataFrame, scenario: str, draw_id: int, strict: bool):
+        self.forecast_marshall.dump(raw_outputs,
+                                    key=MKeys.forecast_raw_outputs(scenario=scenario, draw_id=draw_id),
+                                    strict=strict)
 
     def load_raw_outputs(self, scenario: str, draw_id: int) -> pd.DataFrame:
         return self.forecast_marshall.load(key=MKeys.forecast_raw_outputs(scenario=scenario, draw_id=draw_id))

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -132,9 +132,14 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str):
     covariates = covariates.reset_index()
     outputs = pd.concat([infections, deaths, r_effective], axis=1).reset_index()
 
-    data_interface.save_components(components, scenario_name, draw_id)
-    data_interface.save_raw_covariates(covariates, scenario_name, draw_id)
-    data_interface.save_raw_outputs(outputs, scenario_name, draw_id)
+    # If strict, don't allow overwriting of output files.
+    # Mean level mandate reimposition will run and write these outputs
+    # several times.
+    strict = scenario_spec.algorithm != 'mean_level_mandate_reimposition'
+
+    data_interface.save_components(components, scenario_name, draw_id, strict)
+    data_interface.save_raw_covariates(covariates, scenario_name, draw_id, strict)
+    data_interface.save_raw_outputs(outputs, scenario_name, draw_id, strict)
 
 
 def parse_arguments(argstr: Optional[str] = None) -> Namespace:

--- a/src/covid_model_seiir_pipeline/forecasting/task/mean_level_mandate_reimposition.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/mean_level_mandate_reimposition.py
@@ -51,8 +51,6 @@ def run_mean_level_mandate_reimposition(forecast_version: str, scenario_name: st
     data_interface.save_reimposition_dates(reimposition_date.reset_index(), scenario=scenario_name,
                                            reimposition_number=reimposition_number)
 
-    # TODO: Delete the last stage outputs?
-
 
 def parse_arguments(arg_str: Optional[str] = None) -> Namespace:
     """

--- a/src/covid_model_seiir_pipeline/marshall.py
+++ b/src/covid_model_seiir_pipeline/marshall.py
@@ -188,12 +188,12 @@ class CSVMarshall:
     new marshalling interface.
     """
     # interface methods
-    def dump(self, data: pandas.DataFrame, key):
+    def dump(self, data: pandas.DataFrame, key, strict=True):
         path = self.resolve_key(key)
         if not path.parent.is_dir():
             mkdir(path.parent, parents=True)
         else:
-            if path.exists():
+            if strict and path.exists():
                 msg = f"Cannot dump data for key {key} - would overwrite"
                 raise LookupError(msg)
 
@@ -223,7 +223,10 @@ class CSVMarshall:
 
 class ZipMarshall:
     # interface methods
-    def dump(self, data: pandas.DataFrame, key):
+    def dump(self, data: pandas.DataFrame, key, strict=True):
+        if not strict:
+            raise NotImplementedError
+
         seed, path = self.resolve_key(key)
         with zipfile.ZipFile(self.zip(seed), mode='a') as container:
             with self._open_no_overwrite(container, path, key) as outf:
@@ -309,7 +312,10 @@ class Hdf5Marshall:
     obj_dtype = numpy.dtype('O')
     string_dtype = h5py.string_dtype()
 
-    def dump(self, data, key):
+    def dump(self, data, key, strict=True):
+        if not strict:
+            raise NotImplementedError
+
         seed, group_name, name = self.resolve_key(key)
         with h5py.File(self.hdf5(seed), "a") as container:
             # version file. should we ever update the format it will make life easier

--- a/tests/forecasting/test_data.py
+++ b/tests/forecasting/test_data.py
@@ -91,9 +91,9 @@ class TestForecastDataInterfaceIO:
         )
 
         # Step 1: save files
-        di.save_components(components, scenario="happy", draw_id=4)
+        di.save_components(components, scenario="happy", draw_id=4, strict=True)
         di.save_beta_scales(beta_scales, scenario="happy", draw_id=4)
-        di.save_raw_outputs(forecast_outputs, scenario="happy", draw_id=4)
+        di.save_raw_outputs(forecast_outputs, scenario="happy", draw_id=4, strict=True)
 
         # Step 2: test save location
         # this is sort of cheating, but it ensures that scenario things are


### PR DESCRIPTION
This seems much easier than trying to delete files.  

What's going on is mean level mandate reimposition requires us to run the forecast, do a post processing, run a forecast, do a post processing, etc., using the file system to communicate between different stages.  We don't need to keep any data except for the last forecast.  

So: allow overwrites.