### PR TITLE
Collijk/feature/workflow specification from config

### DIFF
--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -12,16 +12,17 @@ from covid_model_seiir_pipeline.workflow_template import (
 
 class RegressionTaskParams(ExecutorParameters):
 
-    def __init__(self,
-                 queue,
-                 max_runtime_seconds=None,
-                 m_mem_free='2G',
-                 num_cores=1, **kwargs):
-        super().__init__(num_cores=num_cores,
-                         queue=queue,
-                         max_runtime_seconds=max_runtime_seconds,
-                         m_mem_free=m_mem_free,
-                         **kwargs)
+    @property
+    def default_cores(self) -> int:
+        return 1
+
+    @property
+    def default_memory(self) -> str:
+        return '2G'
+
+    @property
+    def default_runtime(self) -> int:
+        return 3000
 
 
 class RegressionWorkflowSpecification(WorkflowSpecification):

--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -14,7 +14,7 @@ class RegressionTaskParams(ExecutorParameters):
 
     def __init__(self,
                  queue,
-                 max_runtime_seconds=3000,
+                 max_runtime_seconds=None,
                  m_mem_free='2G',
                  num_cores=1, **kwargs):
         super().__init__(num_cores=num_cores,

--- a/src/covid_model_seiir_pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/regression/workflow.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from jobmon.client.swarm.executors.base import ExecutorParameters
 
 from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowTemplate
@@ -20,8 +22,22 @@ class BetaRegressionTaskTemplate(TaskTemplate):
 
 class RegressionWorkflow(WorkflowTemplate):
 
-    workflow_name_template = 'seiir-regression-{version}'
-    task_templates = {'regression': BetaRegressionTaskTemplate()}
+    @property
+    def workflow_name_template(self) -> str:
+        return 'seiir-regression-{version}'
+
+    def build_task_templates(self, task_specifications: Dict[str, ExecutorParameters]):
+        return {
+            'regression': TaskTemplate(
+                task_name_template="beta_regression_draw_{draw_id}",
+                command_template=(
+                        "beta_regression " +
+                        "--draw-id {draw_id} " +
+                        "--regression-version {regression_version} "
+                ),
+                params=task_specifications['regression']
+            )
+        }
 
     def attach_tasks(self, n_draws: int):
         regression_template = self.task_templates['regression']

--- a/src/covid_model_seiir_pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/regression/workflow.py
@@ -6,21 +6,6 @@ from jobmon.client.swarm.executors.base import ExecutorParameters
 from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowTemplate
 
 
-class BetaRegressionTaskTemplate(TaskTemplate):
-    task_name_template = "beta_regression_draw_{draw_id}"
-    command_template = (
-            f"{shutil.which('beta_regression')} " +
-            "--draw-id {draw_id} " +
-            "--regression-version {regression_version} "
-    )
-    params = ExecutorParameters(
-        max_runtime_seconds=3000,
-        m_mem_free='2G',
-        num_cores=1,
-        queue='d.q'
-    )
-
-
 class RegressionWorkflow(WorkflowTemplate):
 
     @property
@@ -32,7 +17,7 @@ class RegressionWorkflow(WorkflowTemplate):
             'regression': TaskTemplate(
                 task_name_template="beta_regression_draw_{draw_id}",
                 command_template=(
-                        "beta_regression " +
+                        f"{shutil.which('beta_regression')} " +
                         "--draw-id {draw_id} " +
                         "--regression-version {regression_version} "
                 ),

--- a/src/covid_model_seiir_pipeline/workflow_template.py
+++ b/src/covid_model_seiir_pipeline/workflow_template.py
@@ -2,49 +2,94 @@ import abc
 from typing import Dict
 
 from jobmon.client import Workflow, BashTask
-from jobmon.client.swarm.executors.base import ExecutorParameters
+from jobmon.client.swarm.executors.base import ExecutorParameters as ExecutorParameters_
 from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
 
 from covid_model_seiir_pipeline import utilities
 
+DEFAULT_PROJECT = 'proj_dq'
+DEFAULT_QUEUE = 'd.q'
+
+
+class ExecutorParameters(ExecutorParameters_):
+
+    def to_dict(self):
+        return self.to_wire()
+
+
+class WorkflowSpecification:
+
+    def __init__(self, project: str, task_specifications: Dict[str, ExecutorParameters]):
+        self.project = project
+        self.task_specifications = task_specifications
+
+    def to_dict(self):
+        return {
+            'project': self.project,
+            'task_specifications': {
+                task: spec.to_dict() for task, spec in self.task_specifications.items(),
+            }
+        }
+
 
 class TaskTemplate:
+    """Abstract factory for producing SEIIR pipeline tasks."""
 
-    task_name_template: str = None
-    command_template: str = None
-    params: ExecutorParameters = None
+    def __init__(self,
+                 task_name_template: str,
+                 command_template: str,
+                 params: ExecutorParameters,
+                 max_attempts: int = 1):
+        self.task_name_template = task_name_template
+        self.command_template = command_template
+        self.params = params
+        self.max_attempts = max_attempts
 
     def get_task(self, *_, **kwargs) -> BashTask:
         task = BashTask(
             command=self.command_template.format(**kwargs),
             name=self.task_name_template.format(**kwargs),
             executor_parameters=self.params,
-            max_attempts=1
+            max_attempts=self.max_attempts
         )
         return task
 
 
 class WorkflowTemplate:
 
-    workflow_name_template: str = None
-    task_templates: Dict[str, TaskTemplate] = None
-
-    def __init__(self, version: str):
+    def __init__(self, version: str, workflow_spec: WorkflowSpecification):
         self.version = version
+
         stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
 
         self.workflow = Workflow(
             workflow_args=self.workflow_name_template.format(version=version),
-            project="proj_covid",
+            project=workflow_spec.project,
             stderr=stderr,
             stdout=stdout,
             seconds_until_timeout=60*60*24,
             resume=True
         )
 
+        self._task_templates = self.build_task_templates(workflow_spec.task_specifications)
+
+
+    @abc.abstractmethod
+    @property
+    def workflow_name_template(self) -> str:
+        ...
+
+    @abc.abstractmethod
+    def build_task_templates(self, task_specifications: Dict[str, ExecutorParameters]):
+        ...
+
     @abc.abstractmethod
     def attach_tasks(self, *args, **kwargs):
         pass
+
+    @property
+    def task_templates(self) -> Dict[str, TaskTemplate]:
+        return self._task_templates
 
     def run(self):
         execution_status = self.workflow.run()

--- a/src/covid_model_seiir_pipeline/workflow_template.py
+++ b/src/covid_model_seiir_pipeline/workflow_template.py
@@ -13,6 +13,39 @@ DEFAULT_QUEUE = 'd.q'
 
 class ExecutorParameters(ExecutorParameters_):
 
+    def __init__(self,
+                 queue: str,
+                 max_runtime_seconds: int = None,
+                 m_mem_free: str = None,
+                 num_cores: int = None,
+                 **kwargs):
+        if max_runtime_seconds is None:
+            max_runtime_seconds = self.default_runtime
+        if m_mem_free is None:
+            m_mem_free = self.default_memory
+        if num_cores is None:
+            num_cores = self.default_cores
+        super().__init__(num_cores=num_cores,
+                         queue=queue,
+                         max_runtime_seconds=max_runtime_seconds,
+                         m_mem_free=m_mem_free,
+                         **kwargs)
+
+    @abc.abstractmethod
+    @property
+    def default_runtime(self):
+        ...
+
+    @abc.abstractmethod
+    @property
+    def default_memory(self):
+        ...
+
+    @abc.abstractmethod
+    @property
+    def default_cores(self):
+        ...
+
     def to_dict(self):
         return self.to_wire()
 

--- a/src/covid_model_seiir_pipeline/workflow_template.py
+++ b/src/covid_model_seiir_pipeline/workflow_template.py
@@ -33,17 +33,17 @@ class ExecutorParameters(ExecutorParameters_):
 
     @abc.abstractmethod
     @property
-    def default_runtime(self):
+    def default_runtime(self) -> int:
         ...
 
     @abc.abstractmethod
     @property
-    def default_memory(self):
+    def default_memory(self) -> str:
         ...
 
     @abc.abstractmethod
     @property
-    def default_cores(self):
+    def default_cores(self) -> int:
         ...
 
     def to_dict(self):


### PR DESCRIPTION
Sketching out the design to connect the workflow specification up to the configuration system.  This is not tested yet.

The goal here is to allow an additional configuration block `workflow` in the forecast and regression specifications that'll allow the user to, e.g., change which queue we run on or to fiddle with runtime or memory for pipeline tasks.

