### PR TITLE
Collijk/feature/postprocessing specification

### DIFF
--- a/specification_templates/forecast.yaml
+++ b/specification_templates/forecast.yaml
@@ -76,8 +76,3 @@ scenarios:
       lri_mortality: 'reference'
       proportion_under_100m: 'reference'
       proportion_over_2_5k: 'reference'
-postprocessing:
-  resampling:
-    reference_scenario: 'worse'
-    lower_quantile: 0.025
-    upper_quantile: 0.975

--- a/specification_templates/postprocessing.yaml
+++ b/specification_templates/postprocessing.yaml
@@ -7,11 +7,12 @@ data:
   output_root: ''
 resampling:
   reference_scenario: 'worse'
+  reference_date: '2020-01-01'
   lower_quantile: 0.025
   upper_quantile: 0.975
 splicing:
-  locations: [33, 85, 555, 4693]
-  forecast_version: '/path/to/other/forecast/version'
+  - locations: [33, 85, 555, 4693]
+    forecast_version: '/path/to/other/forecast/version'
 aggregation:
   location_file: ''
   location_set_id: 111

--- a/specification_templates/postprocessing.yaml
+++ b/specification_templates/postprocessing.yaml
@@ -1,0 +1,18 @@
+data:
+  forecast_version: 'best'
+  include_scenarios:
+    - 'worse'
+    - 'reference'
+    - 'best_masks'
+  output_root: ''
+resampling:
+  reference_scenario: 'worse'
+  lower_quantile: 0.025
+  upper_quantile: 0.975
+splicing:
+  locations: [33, 85, 555, 4693]
+  forecast_version: '/path/to/other/forecast/version'
+aggregation:
+  location_file: ''
+  location_set_id: 111
+  location_set_version_id: 771

--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -96,46 +96,30 @@ class ScenarioSpecification:
         return {k: v for k, v in asdict(self).items() if k != 'name'}
 
 
-@dataclass
-class PostprocessingSpecification:
-
-    resampling: Dict = field(default_factory=dict)
-
-    def to_dict(self) -> Dict:
-        return asdict(self)
-
-
 class ForecastSpecification(Specification):
     """Specification for a beta forecast run."""
 
     def __init__(self, data: ForecastData,
-                 postprocessing: PostprocessingSpecification,
                  *scenarios: ScenarioSpecification):
         self._data = data
-        self._postprocessing = postprocessing
         self._scenarios = {s.name: s for s in scenarios}
 
     @classmethod
     def parse_spec_dict(cls, forecast_spec_dict: Dict) -> Tuple:
         """Construct forecast specification args from a dict."""
         data = ForecastData(**forecast_spec_dict.get('data', {}))
-        postprocessing = PostprocessingSpecification(**forecast_spec_dict.get('postprocessing', {}))
         scenario_dicts = forecast_spec_dict.get('scenarios', {})
         scenarios = []
         for name, scenario_spec in scenario_dicts.items():
             scenarios.append(ScenarioSpecification(name, **scenario_spec))
         if not scenarios:
             scenarios.append(ScenarioSpecification())
-        return tuple(itertools.chain([data, postprocessing], scenarios))
+        return tuple(itertools.chain([data], scenarios))
 
     @property
     def data(self) -> 'ForecastData':
         """The forecast data specification."""
         return self._data
-
-    @property
-    def postprocessing(self) -> PostprocessingSpecification:
-        return self._postprocessing
 
     @property
     def scenarios(self) -> Dict[str, ScenarioSpecification]:
@@ -146,6 +130,101 @@ class ForecastSpecification(Specification):
         """Convert the specification to a dict."""
         return {
             'data': self.data.to_dict(),
-            'postprocessing': self.postprocessing.to_dict(),
             'scenarios': {k: v.to_dict() for k, v in self._scenarios.items()}
+        }
+
+
+@dataclass
+class PostprocessingData:
+    """Specifies the inputs and outputs for postprocessing."""
+    forecast_version: str = field(default='best')
+    include_scenarios: list = field(default_factory=lambda: ['worse', 'reference', 'best_masks'])
+    output_root: str = field(default='')
+
+    def to_dict(self) -> Dict:
+        """Converts to a dict, coercing list-like items to lists."""
+        return asdict(self)
+
+
+@dataclass
+class ResamplingSpecification:
+    """Specifies parameters for draw resampling."""
+    reference_scenario: str = field(default='worse')
+    lower_quantile: float = field(default=0.025)
+    upper_quantile: float = field(default=0.975)
+
+    def to_dict(self) -> Dict:
+        """Converts to a dict, coercing list-like items to lists."""
+        return asdict(self)
+
+
+@dataclass
+class SplicingSpecification:
+    """Specifies locations and inputs for splicing."""
+    locations: list = field(default_factory=list)
+    forecast_version: str = field(default='')
+
+    def to_dict(self) -> Dict:
+        """Converts to a dict, coercing list-like items to lists."""
+        return asdict(self)
+
+
+@dataclass
+class AggregationSpecification:
+    """Specifies hierarchy and parameters for aggregation."""
+    location_file: str = field(default='')
+    location_set_id: int = field(default=None)
+    location_set_version_id: int = field(default=None)
+
+    def to_dict(self) -> Dict:
+        """Converts to a dict, coercing list-like items to lists."""
+        return asdict(self)
+
+
+class PostprocessingSpecification(Specification):
+
+    def __init__(self,
+                 data: PostprocessingData,
+                 resampling: ResamplingSpecification,
+                 splicing: SplicingSpecification,
+                 aggregation: AggregationSpecification):
+        self._data = data
+        self._resampling = resampling
+        self._splicing = splicing
+        self._aggregation = aggregation
+
+    @classmethod
+    def parse_spec_dict(cls, postprocessing_spec_dict: Dict) -> Tuple:
+        """Construct postprocessing specification args from a dict."""
+        data = PostprocessingData(**postprocessing_spec_dict.get('data', {}))
+        resampling = ResamplingSpecification(**postprocessing_spec_dict.get('resampling', {}))
+        splicing = SplicingSpecification(**postprocessing_spec_dict.get('splicing', {}))
+        aggregation = AggregationSpecification(**postprocessing_spec_dict.get('aggregation', {}))
+
+        return data, resampling, splicing, aggregation
+
+    @property
+    def data(self) -> PostprocessingData:
+        """The postprocessing data specification."""
+        return self._data
+
+    @property
+    def resampling(self) -> ResamplingSpecification:
+        return self._resampling
+
+    @property
+    def splicing(self) -> SplicingSpecification:
+        return self._splicing
+
+    @property
+    def aggregation(self) -> AggregationSpecification:
+        return self._aggregation
+
+    def to_dict(self):
+        """Convert the specification to a dict."""
+        return {
+            'data': self.data.to_dict(),
+            'resampling': self.resampling.to_dict(),
+            'splicing': self.splicing.to_dict(),
+            'aggregation': self.aggregation.to_dict()
         }


### PR DESCRIPTION
This sets up the specification interface to give some more (currently unimplemented) features to post-processing and allow us to use the postprocessing stage separately from forecast.

Note I'm targeting a feature branch so I can break this work into chunks.  I'm treating this as greenfield development and don't expect to have something that works end to end for a couple more PRs.