### PR TITLE
Collijk/feature/optimize mandate reimposition

### DIFF
--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -146,13 +146,22 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str, *
             logger.info('Forecasting beta and components.')
             betas = model.forecast_beta(covariate_pred, coefficients, beta_scales)
             seir_parameters = model.prep_seir_parameters(betas, thetas, scenario_data)
-            future_components = model.run_normal_ode_model_by_location(
-                initial_condition,
+
+            # The ode is done as a loop over the locations in the initial condition.
+            # Subset here to only the locations that reimpose mandates.
+            initial_condition_subset = initial_condition.loc[reimposition_date.index]
+            future_components_subset = model.run_normal_ode_model_by_location(
+                initial_condition_subset,
                 beta_params,
                 seir_parameters,
                 scenario_spec,
                 compartment_info,
             )
+            future_components = (future_components
+                                 .drop(future_components_subset.index)
+                                 .append(future_components_subset)
+                                 .sort_index())
+
             logger.info('Processing ODE results and computing deaths and infections.')
             components, infections, deaths, r_effective = model.compute_output_metrics(
                 infection_data,

--- a/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/beta_forecast.py
@@ -148,7 +148,8 @@ def run_beta_forecast(draw_id: int, forecast_version: str, scenario_name: str, *
             seir_parameters = model.prep_seir_parameters(betas, thetas, scenario_data)
 
             # The ode is done as a loop over the locations in the initial condition.
-            # Subset here to only the locations that reimpose mandates.
+            # As locations that don't reimpose mandates produce identical forecasts,
+            # subset here to only the locations that reimpose mandates for speed.
             initial_condition_subset = initial_condition.loc[reimposition_date.index]
             future_components_subset = model.run_normal_ode_model_by_location(
                 initial_condition_subset,


### PR DESCRIPTION
Mandate reimposition happens ~4 times, but only on an ever decreasing subset of the population.

Location count:
- normal forecast: ~400
- first reimposition: ~150
- second reimposition: ~50
- third reimposition: ~10
- fourth reimposition: <5

The forecast process is totally compute bound by the ode forecast now that we have the 32 compartments (literally a simple python loop).  This optimization should take us from running ~400 x 5 = 2000 forecasts to running ~400 + 150 + 50 + 10 + 5 = 615 forecasts for about a 3x speedup.