### PR TITLE
Collijk/feature/workflow specification from config take 2

### DIFF
--- a/specification_templates/forecast.yaml
+++ b/specification_templates/forecast.yaml
@@ -2,6 +2,30 @@ data:
   regression_version: '2020_12_03.02'
   covariate_version: '2020_12_01.05'
   output_root: ''
+workflow:
+  project: 'proj_covid'
+  queue: 'd.q'
+  tasks:
+    scaling:
+      max_runtime_seconds: 5000
+      m_mem_free: '5G'
+      num_cores: 26
+    forecast:
+      max_runtime_seconds: 15000
+      m_mem_free: '5G'
+      num_cores: 1
+    sentinel:
+      max_runtime_seconds: 1000
+      m_mem_free: '1G'
+      num_cores: 1
+    resample:
+      max_runtime_seconds: 5000
+      m_mem_free: '50G'
+      num_cores: 26
+    postprocess:
+      max_runtime_seconds: 15000
+      m_mem_free: '150G'
+      num_cores: 26
 scenarios:
   worse:
     algorithm: 'normal' # normal, draw_level_mandate_reimposition
@@ -129,7 +153,7 @@ scenarios:
     population_partition: 'high_and_low_risk'
     beta_scaling:
       window_size: 42
-      average_over_min: 7 
+      average_over_min: 7
       average_over_max: 42
       offset_deaths_lower: 150
       offset_deaths_upper: 300
@@ -158,7 +182,7 @@ scenarios:
     population_partition: 'high_and_low_risk'
     beta_scaling:
       window_size: 42
-      average_over_min: 7 
+      average_over_min: 7
       average_over_max: 42
       offset_deaths_lower: 150
       offset_deaths_upper: 300

--- a/specification_templates/forecast.yaml
+++ b/specification_templates/forecast.yaml
@@ -4,7 +4,7 @@ data:
   output_root: ''
 workflow:
   project: 'proj_covid'
-  queue: 'all.q'
+  queue: 'd.q'
   tasks:
     scaling:
       max_runtime_seconds: 5000

--- a/specification_templates/forecast.yaml
+++ b/specification_templates/forecast.yaml
@@ -1,10 +1,10 @@
 data:
-  regression_version: '2020_12_03.02'
+  regression_version: '2020_12_07.07'
   covariate_version: '2020_12_01.05'
   output_root: ''
 workflow:
   project: 'proj_covid'
-  queue: 'd.q'
+  queue: 'all.q'
   tasks:
     scaling:
       max_runtime_seconds: 5000

--- a/specification_templates/regression.yaml
+++ b/specification_templates/regression.yaml
@@ -38,7 +38,7 @@ covariates:
   pneumonia:
     order: 0
     use_re: False
-    gprior: [0.0, 0.1]
+    gprior: [0.0, 1000.0]
     bounds: [0.8, 1.3]
     re_var: 1.0
     draws: False
@@ -52,15 +52,15 @@ covariates:
   mask_use:
     order: 0
     use_re: False
-    gprior: [0., 0.21]
-    bounds: [-1000.0, -0.50]
+    gprior: [-0.654, 0.01]
+    bounds: [-1000.0, 0.0]
     re_var: 1.0
     draws: False
   testing:
     order: 0
     use_re: False
-    gprior: [0.0, 40.0]
-    bounds: [-80.0, 0.0]
+    gprior: [0.0, 1000.]
+    bounds: [-1000.0, 0.0]
     re_var: 1.0
     draws: False
   air_pollution_pm_2_5:
@@ -73,7 +73,7 @@ covariates:
   smoking_prevalence:
     order: 0
     use_re: False
-    gprior: [0.0, 0.5]
+    gprior: [0.0, 1000]
     bounds: [0.0, 1.0]
     re_var: 1.0
     draws: False
@@ -94,7 +94,7 @@ covariates:
   proportion_over_2_5k:
     order: 0
     use_re: False
-    gprior: [0.0, 0.001]
+    gprior: [0.0, 1000.0]
     bounds: [0.0, 1000.0]
     re_var: 1.0
     draws: False

--- a/specification_templates/regression.yaml
+++ b/specification_templates/regression.yaml
@@ -4,6 +4,14 @@ data:
   location_set_version_id: ''
   location_set_file: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/location_metadata_771.csv'
   output_root: ''
+workflow:
+  project: 'proj_covid'
+  queue: 'd.q'
+  tasks:
+    regression:
+      max_runtime_seconds: 3000
+      m_mem_free: '2G'
+      num_cores: 1
 parameters:
   n_draws: 1000
   day_shift: [0, 8]

--- a/src/covid_model_seiir_pipeline/forecasting/main.py
+++ b/src/covid_model_seiir_pipeline/forecasting/main.py
@@ -23,7 +23,8 @@ def do_beta_forecast(app_metadata: cli_tools.Metadata,
     forecast_specification.dump(data_interface.forecast_paths.forecast_specification)
 
     if not preprocess_only:
-        forecast_wf = ForecastWorkflow(forecast_specification.data.output_root)
+        forecast_wf = ForecastWorkflow(forecast_specification.data.output_root,
+                                       forecast_specification.workflow)
         n_draws = data_interface.get_n_draws()
 
         forecast_wf.attach_tasks(n_draws=n_draws,

--- a/src/covid_model_seiir_pipeline/forecasting/postprocessing_lib.py
+++ b/src/covid_model_seiir_pipeline/forecasting/postprocessing_lib.py
@@ -7,35 +7,34 @@ import numpy as np
 import pandas as pd
 
 from covid_model_seiir_pipeline.forecasting.data import ForecastDataInterface
-from covid_model_seiir_pipeline.forecasting.specification import FORECAST_SCALING_CORES
 
 
 # TODO: make a model subpackage and put this there.
 
 
-def load_deaths(scenario: str, data_interface: ForecastDataInterface):
-    deaths, *_ = load_output_data(scenario, data_interface)
+def load_deaths(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
+    deaths, *_ = load_output_data(scenario, data_interface, num_cores)
     return deaths
 
 
-def load_infections(scenario: str, data_interface: ForecastDataInterface):
-    _, infections, *_ = load_output_data(scenario, data_interface)
+def load_infections(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
+    _, infections, *_ = load_output_data(scenario, data_interface, num_cores)
     return infections
 
 
-def load_r_effective(scenario: str, data_interface: ForecastDataInterface):
-    _, _, r_effective = load_output_data(scenario, data_interface)
+def load_r_effective(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
+    _, _, r_effective = load_output_data(scenario, data_interface, num_cores)
     return r_effective
 
 
-def load_output_data(scenario: str, data_interface: ForecastDataInterface):
+def load_output_data(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
     _runner = functools.partial(
         load_output_data_by_draw,
         scenario=scenario,
         data_interface=data_interface,
     )
     draws = range(data_interface.get_n_draws())
-    with multiprocessing.Pool(FORECAST_SCALING_CORES) as pool:
+    with multiprocessing.Pool(num_cores) as pool:
         outputs = pool.map(_runner, draws)
     deaths, infections, r_effective = zip(*outputs)
 
@@ -52,13 +51,13 @@ def load_output_data_by_draw(draw_id: int, scenario: str,
     return deaths, infections, r_effective
 
 
-def load_coefficients(scenario: str, data_interface: ForecastDataInterface):
+def load_coefficients(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
     _runner = functools.partial(
         load_coefficients_by_draw,
         data_interface=data_interface
     )
     draws = range(data_interface.get_n_draws())
-    with multiprocessing.Pool(FORECAST_SCALING_CORES) as pool:
+    with multiprocessing.Pool(num_cores) as pool:
         outputs = pool.map(_runner, draws)
     return outputs
 
@@ -71,14 +70,14 @@ def load_coefficients_by_draw(draw_id: int, data_interface: ForecastDataInterfac
     return coefficients
 
 
-def load_scaling_parameters(scenario: str, data_interface: ForecastDataInterface):
+def load_scaling_parameters(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
     _runner = functools.partial(
         load_scaling_parameters_by_draw,
         scenario=scenario,
         data_interface=data_interface,
     )
     draws = range(data_interface.get_n_draws())
-    with multiprocessing.Pool(FORECAST_SCALING_CORES) as pool:
+    with multiprocessing.Pool(num_cores) as pool:
         outputs = pool.map(_runner, draws)
     return outputs
 
@@ -92,7 +91,7 @@ def load_scaling_parameters_by_draw(draw_id: int, scenario: str, data_interface:
 
 
 def load_covariate(covariate: str, time_varying: bool, scenario: str,
-                   data_interface: ForecastDataInterface) -> List[pd.Series]:
+                   data_interface: ForecastDataInterface, num_cores: int) -> List[pd.Series]:
     _runner = functools.partial(
         load_covariate_by_draw,
         covariate=covariate,
@@ -101,7 +100,7 @@ def load_covariate(covariate: str, time_varying: bool, scenario: str,
         data_interface=data_interface,
     )
     draws = range(data_interface.get_n_draws())
-    with multiprocessing.Pool(FORECAST_SCALING_CORES) as pool:
+    with multiprocessing.Pool(num_cores) as pool:
         outputs = pool.map(_runner, draws)
 
     return outputs
@@ -121,14 +120,14 @@ def load_covariate_by_draw(draw_id: int,
     return covariate_data
 
 
-def load_betas(scenario: str, data_interface: ForecastDataInterface) -> List[pd.Series]:
+def load_betas(scenario: str, data_interface: ForecastDataInterface, num_cores: int) -> List[pd.Series]:
     _runner = functools.partial(
         load_betas_by_draw,
         scenario=scenario,
         data_interface=data_interface,
     )
     draws = range(data_interface.get_n_draws())
-    with multiprocessing.Pool(FORECAST_SCALING_CORES) as pool:
+    with multiprocessing.Pool(num_cores) as pool:
         betas = pool.map(_runner, draws)
     return betas
 
@@ -141,13 +140,13 @@ def load_betas_by_draw(draw_id: int, scenario: str, data_interface: ForecastData
     return draw_betas
 
 
-def load_beta_residuals(scenario: str, data_interface: ForecastDataInterface) -> List[pd.Series]:
+def load_beta_residuals(scenario: str, data_interface: ForecastDataInterface, num_cores: int) -> List[pd.Series]:
     _runner = functools.partial(
         load_beta_residuals_by_draw,
         data_interface=data_interface,
     )
     draws = range(data_interface.get_n_draws())
-    with multiprocessing.Pool(FORECAST_SCALING_CORES) as pool:
+    with multiprocessing.Pool(num_cores) as pool:
         beta_residuals = pool.map(_runner, draws)
     return beta_residuals
 
@@ -172,11 +171,11 @@ def load_elastispliner_inputs(data_interface: ForecastDataInterface) -> pd.DataF
     return es_inputs
 
 
-def load_es_noisy(scenario: str, data_interface: ForecastDataInterface):
+def load_es_noisy(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
     return load_elastispliner_outputs(data_interface, noisy=True)
 
 
-def load_es_smoothed(scenario: str, data_interface: ForecastDataInterface):
+def load_es_smoothed(scenario: str, data_interface: ForecastDataInterface, num_cores: int):
     return load_elastispliner_outputs(data_interface, noisy=False)
 
 

--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -181,6 +181,7 @@ class ForecastSpecification(Specification):
     def parse_spec_dict(cls, forecast_spec_dict: Dict) -> Tuple:
         """Construct forecast specification args from a dict."""
         data = ForecastData(**forecast_spec_dict.get('data', {}))
+        workflow = ForecastWorkflowSpecification(**forecast_spec_dict.get('workflow', {}))
         postprocessing = PostprocessingSpecification(**forecast_spec_dict.get('postprocessing', {}))
         scenario_dicts = forecast_spec_dict.get('scenarios', {})
         scenarios = []
@@ -188,7 +189,7 @@ class ForecastSpecification(Specification):
             scenarios.append(ScenarioSpecification(name, **scenario_spec))
         if not scenarios:
             scenarios.append(ScenarioSpecification())
-        return tuple(itertools.chain([data, postprocessing], scenarios))
+        return tuple(itertools.chain([data, workflow, postprocessing], scenarios))
 
     @property
     def data(self) -> ForecastData:

--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -1,17 +1,61 @@
 from dataclasses import dataclass, field
 import itertools
-from typing import Dict, Tuple, Union
+from typing import Dict, NamedTuple, Tuple, Union
 
 from covid_model_seiir_pipeline.utilities import Specification, asdict
+from covid_model_seiir_pipeline.workflow_template import TaskSpecification, WorkflowSpecification
 
-# TODO: Extract these into specification, maybe.  At least allow overrides
-#    for the queue from the command line.
-FORECAST_RUNTIME = 15000
-FORECAST_MEMORY = '5G'
-POSTPROCESS_MEMORY = '150G'
-FORECAST_CORES = 1
-FORECAST_SCALING_CORES = 26
-FORECAST_QUEUE = 'd.q'
+
+class __ForecastJobs(NamedTuple):
+    scaling: str = 'scaling'
+    forecast: str = 'forecast'
+    sentinel: str = 'sentinel'
+    resample: str = 'resample'
+    postprocess: str = 'postprocess'
+
+
+FORECAST_JOBS = __ForecastJobs()
+
+
+class ScalingTaskSpecification(TaskSpecification):
+    default_max_runtime_seconds = 5000
+    default_m_mem_free = '5G'
+    default_num_cores = 26
+
+
+class ForecastTaskSpecification(TaskSpecification):
+    default_max_runtime_seconds = 15000
+    default_m_mem_free = '5G'
+    default_num_cores = 1
+
+
+class SentinelTaskSpecification(TaskSpecification):
+    default_max_runtime_seconds = 1000
+    default_m_mem_free = '1G'
+    default_num_cores = 1
+
+
+class ResampleTaskSpecification(TaskSpecification):
+    default_max_runtime_seconds = 5000
+    default_m_mem_free = '50G'
+    default_num_cores = 26
+
+
+class PostprocessingTaskSpecification(TaskSpecification):
+    default_max_runtime_seconds = 15000
+    default_m_mem_free = '150G'
+    default_num_cores = 26
+
+
+class ForecastWorkflowSpecification(WorkflowSpecification):
+
+    tasks = {
+        FORECAST_JOBS.scaling: ScalingTaskSpecification,
+        FORECAST_JOBS.forecast: ForecastTaskSpecification,
+        FORECAST_JOBS.sentinel: SentinelTaskSpecification,
+        FORECAST_JOBS.resample: ResampleTaskSpecification,
+        FORECAST_JOBS.postprocess: PostprocessingTaskSpecification,
+    }
 
 
 @dataclass
@@ -118,10 +162,13 @@ class ForecastSpecification(Specification):
     """Specification for a beta forecast run."""
 
     def __init__(self, data: ForecastData,
+                 workflow: ForecastWorkflowSpecification,
                  postprocessing: PostprocessingSpecification,
                  *scenarios: ScenarioSpecification):
         self._data = data
+        self._workflow = workflow
         self._postprocessing = postprocessing
+
         self._scenarios = {s.name: s for s in scenarios}
 
     @classmethod
@@ -138,9 +185,14 @@ class ForecastSpecification(Specification):
         return tuple(itertools.chain([data, postprocessing], scenarios))
 
     @property
-    def data(self) -> 'ForecastData':
+    def data(self) -> ForecastData:
         """The forecast data specification."""
         return self._data
+
+    @property
+    def workflow(self) -> ForecastWorkflowSpecification:
+        """The workflow specification for the forecast."""
+        return self._workflow
 
     @property
     def postprocessing(self) -> PostprocessingSpecification:
@@ -155,6 +207,7 @@ class ForecastSpecification(Specification):
         """Convert the specification to a dict."""
         return {
             'data': self.data.to_dict(),
+            'workflow': self.workflow.to_dict(),
             'postprocessing': self.postprocessing.to_dict(),
             'scenarios': {k: v.to_dict() for k, v in self._scenarios.items()}
         }

--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -18,36 +18,42 @@ FORECAST_JOBS = __ForecastJobs()
 
 
 class ScalingTaskSpecification(TaskSpecification):
+    """Specification of execution parameters for beta scaling tasks."""
     default_max_runtime_seconds = 5000
     default_m_mem_free = '5G'
     default_num_cores = 26
 
 
 class ForecastTaskSpecification(TaskSpecification):
+    """Specification of execution parameters for beta forecasting tasks."""
     default_max_runtime_seconds = 15000
     default_m_mem_free = '5G'
     default_num_cores = 1
 
 
 class SentinelTaskSpecification(TaskSpecification):
+    """Specification of execution parameters for workflow join tasks."""
     default_max_runtime_seconds = 1000
     default_m_mem_free = '1G'
     default_num_cores = 1
 
 
 class ResampleTaskSpecification(TaskSpecification):
+    """Specification of execution parameters for draw resample mapping tasks."""
     default_max_runtime_seconds = 5000
     default_m_mem_free = '50G'
     default_num_cores = 26
 
 
 class PostprocessingTaskSpecification(TaskSpecification):
+    """Specification of execution parameters for postprocessing tasks."""
     default_max_runtime_seconds = 15000
     default_m_mem_free = '150G'
     default_num_cores = 26
 
 
 class ForecastWorkflowSpecification(WorkflowSpecification):
+    """Specification of execution parameters for forecasting workflows."""
 
     tasks = {
         FORECAST_JOBS.scaling: ScalingTaskSpecification,

--- a/src/covid_model_seiir_pipeline/forecasting/specification.py
+++ b/src/covid_model_seiir_pipeline/forecasting/specification.py
@@ -3,7 +3,7 @@ import itertools
 from typing import Dict, NamedTuple, Tuple, Union
 
 from covid_model_seiir_pipeline.utilities import Specification, asdict
-from covid_model_seiir_pipeline.workflow_template import TaskSpecification, WorkflowSpecification
+from covid_model_seiir_pipeline.workflow_tools.specification import TaskSpecification, WorkflowSpecification
 
 
 class __ForecastJobs(NamedTuple):

--- a/src/covid_model_seiir_pipeline/forecasting/task/postprocessing.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/postprocessing.py
@@ -9,14 +9,18 @@ import pandas as pd
 import yaml
 
 from covid_model_seiir_pipeline import static_vars
-from covid_model_seiir_pipeline.forecasting.specification import ForecastSpecification, ScenarioSpecification
+from covid_model_seiir_pipeline.forecasting.specification import (
+    ForecastSpecification,
+    ScenarioSpecification,
+    FORECAST_JOBS
+)
 from covid_model_seiir_pipeline.forecasting.data import ForecastDataInterface
 from covid_model_seiir_pipeline.forecasting import postprocessing_lib as pp
 
 
 class MeasureConfig:
     def __init__(self,
-                 loader: Callable[[str, ForecastDataInterface], Any],
+                 loader: Callable[[str, ForecastDataInterface, int], Any],
                  label: str,
                  calculate_cumulative: bool = False,
                  cumulative_label: str = None,
@@ -30,7 +34,7 @@ class MeasureConfig:
 
 class CovariateConfig:
     def __init__(self,
-                 loader: Callable[[str, bool, str, ForecastDataInterface], List[pd.Series]],
+                 loader: Callable[[str, bool, str, ForecastDataInterface, int], List[pd.Series]],
                  label: str,
                  time_varying: bool = False,
                  draw_level: bool = False,
@@ -192,10 +196,11 @@ MISCELLANEOUS = {
 
 def postprocess_measure(data_interface: ForecastDataInterface,
                         resampling_map: Dict[int, Dict[str, List[int]]],
-                        scenario_name: str, measure: str) -> None:
+                        scenario_name: str, measure: str,
+                        num_cores: int) -> None:
     measure_config = MEASURES[measure]
     logger.info(f'Loading {measure}.')
-    measure_data = measure_config.loader(scenario_name, data_interface)
+    measure_data = measure_config.loader(scenario_name, data_interface, num_cores)
     if isinstance(measure_data, (list, tuple)):
         logger.info(f'Concatenating {measure}.')
         measure_data = pd.concat(measure_data, axis=1)
@@ -225,10 +230,12 @@ def postprocess_measure(data_interface: ForecastDataInterface,
 def postprocess_covariate(data_interface: ForecastDataInterface,
                           resampling_map: Dict[int, Dict[str, List[int]]],
                           scenario_spec: ScenarioSpecification,
-                          scenario_name: str, covariate: str) -> None:
+                          scenario_name: str, covariate: str,
+                          num_cores: int) -> None:
     covariate_config = COVARIATES[covariate]
     logger.info(f'Loading {covariate}.')
-    covariate_data = covariate_config.loader(covariate, covariate_config.time_varying, scenario_name, data_interface)
+    covariate_data = covariate_config.loader(covariate, covariate_config.time_varying,
+                                             scenario_name, data_interface, num_cores)
     logger.info(f'Concatenating and resampling {covariate}.')
     covariate_data = pd.concat(covariate_data, axis=1)
     covariate_data = pp.resample_draws(covariate_data, resampling_map)
@@ -269,7 +276,8 @@ def postprocess_covariate(data_interface: ForecastDataInterface,
 
 
 def postprocess_miscellaneous(data_interface: ForecastDataInterface,
-                              scenario_name: str, measure: str):
+                              scenario_name: str, measure: str,
+                              num_cores: int):
     miscellaneous_config = MISCELLANEOUS[measure]
     logger.info(f'Loading {measure}.')
     miscellaneous_data = miscellaneous_config.loader(data_interface)
@@ -299,13 +307,14 @@ def run_seir_postprocessing(forecast_version: str, scenario_name: str, measure: 
     scenario_spec = forecast_spec.scenarios[scenario_name]
     data_interface = ForecastDataInterface.from_specification(forecast_spec)
     resampling_map = data_interface.load_resampling_map()
+    num_cores = forecast_spec.workflow.task_specifications[FORECAST_JOBS.postprocess].num_cores
 
     if measure in MEASURES:
-        postprocess_measure(data_interface, resampling_map, scenario_name, measure)
+        postprocess_measure(data_interface, resampling_map, scenario_name, measure, num_cores)
     elif measure in COVARIATES:
-        postprocess_covariate(data_interface, resampling_map, scenario_spec, scenario_name, measure)
+        postprocess_covariate(data_interface, resampling_map, scenario_spec, scenario_name, measure, num_cores)
     elif measure in MISCELLANEOUS:
-        postprocess_miscellaneous(data_interface, scenario_name, measure)
+        postprocess_miscellaneous(data_interface, scenario_name, measure, num_cores)
     else:
         raise NotImplementedError(f'Unknown measure {measure}.')
 

--- a/src/covid_model_seiir_pipeline/forecasting/task/postprocessing.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/postprocessing.py
@@ -12,7 +12,7 @@ from covid_model_seiir_pipeline import static_vars
 from covid_model_seiir_pipeline.forecasting.specification import (
     ForecastSpecification,
     ScenarioSpecification,
-    FORECAST_JOBS
+    FORECAST_JOBS,
 )
 from covid_model_seiir_pipeline.forecasting.data import ForecastDataInterface
 from covid_model_seiir_pipeline.forecasting import postprocessing_lib as pp

--- a/src/covid_model_seiir_pipeline/forecasting/task/resample_map.py
+++ b/src/covid_model_seiir_pipeline/forecasting/task/resample_map.py
@@ -7,7 +7,7 @@ from typing import Optional
 import pandas as pd
 
 from covid_model_seiir_pipeline import static_vars
-from covid_model_seiir_pipeline.forecasting.specification import ForecastSpecification
+from covid_model_seiir_pipeline.forecasting.specification import ForecastSpecification, FORECAST_JOBS
 from covid_model_seiir_pipeline.forecasting.data import ForecastDataInterface
 from covid_model_seiir_pipeline.forecasting import postprocessing_lib as pp
 
@@ -18,9 +18,10 @@ def run_resample_map(forecast_version: str) -> None:
     forecast_spec = ForecastSpecification.from_path(
         Path(forecast_version) / static_vars.FORECAST_SPECIFICATION_FILE
     )
+    workflow_spec = forecast_spec.workflow.task_specifications[FORECAST_JOBS.resample]
     resampling_params = forecast_spec.postprocessing.resampling
     data_interface = ForecastDataInterface.from_specification(forecast_spec)
-    deaths, *_ = pp.load_output_data(resampling_params['reference_scenario'], data_interface)
+    deaths, *_ = pp.load_output_data(resampling_params['reference_scenario'], data_interface, workflow_spec.num_cores)
     deaths = pd.concat(deaths, axis=1)
     resampling_map = pp.build_resampling_map(deaths, resampling_params)
     data_interface.save_resampling_map(resampling_map)

--- a/src/covid_model_seiir_pipeline/forecasting/workflow.py
+++ b/src/covid_model_seiir_pipeline/forecasting/workflow.py
@@ -33,12 +33,6 @@ class BetaResidualScalingTaskTemplate(TaskTemplate):
             "--forecast-version {forecast_version} " +
             "--scenario-name {scenario}"
     )
-    params = ExecutorParameters(
-        max_runtime_seconds=FORECAST_RUNTIME,
-        m_mem_free=FORECAST_MEMORY,
-        num_cores=FORECAST_SCALING_CORES,
-        queue=FORECAST_QUEUE
-    )
 
 
 class BetaForecastTaskTemplate(TaskTemplate):
@@ -51,12 +45,6 @@ class BetaForecastTaskTemplate(TaskTemplate):
         "--scenario-name {scenario} " +
         "--extra-id {extra_id}"
     )
-    params = ExecutorParameters(
-        max_runtime_seconds=FORECAST_RUNTIME,
-        m_mem_free=FORECAST_MEMORY,
-        num_cores=FORECAST_CORES,
-        queue=FORECAST_QUEUE
-    )
 
 
 class ResampleMapTaskTemplate(TaskTemplate):
@@ -65,27 +53,16 @@ class ResampleMapTaskTemplate(TaskTemplate):
             f"{shutil.which('resample_map')} " +
             "--forecast-version {forecast_version} "
     )
-    params = ExecutorParameters(
-        max_runtime_seconds=FORECAST_RUNTIME,
-        m_mem_free=POSTPROCESS_MEMORY,
-        num_cores=FORECAST_SCALING_CORES,
-        queue=FORECAST_QUEUE
-    )
 
 
 class PostprocessingTaskTemplate(TaskTemplate):
+
     task_name_template = "{measure}_{scenario}_post_processing"
     command_template = (
             f"{shutil.which('postprocess')} " +
             "--forecast-version {forecast_version} "
             "--scenario-name {scenario} "
             "--measure {measure}"
-    )
-    params = ExecutorParameters(
-        max_runtime_seconds=FORECAST_RUNTIME,
-        m_mem_free=POSTPROCESS_MEMORY,
-        num_cores=FORECAST_SCALING_CORES,
-        queue=FORECAST_QUEUE
     )
 
 
@@ -95,12 +72,6 @@ class JoinSentinelTaskTemplate(TaskTemplate):
     task_name_template = "join_sentinel_{sentinel_id}"
     command_template = (
         "echo {sentinel_id}"
-    )
-    params = ExecutorParameters(
-        max_runtime_seconds=1000,
-        m_mem_free="1G",
-        num_cores=1,
-        queue=FORECAST_QUEUE,
     )
 
     def get_task(self, *args, **kwargs):

--- a/src/covid_model_seiir_pipeline/forecasting/workflow.py
+++ b/src/covid_model_seiir_pipeline/forecasting/workflow.py
@@ -6,16 +6,16 @@ from jobmon.client import BashTask
 
 from covid_model_seiir_pipeline.workflow_tools.template import (
     TaskTemplate,
-    WorkflowTemplate
+    WorkflowTemplate,
 )
 from covid_model_seiir_pipeline.forecasting.specification import (
     ScenarioSpecification,
-    FORECAST_JOBS
+    FORECAST_JOBS,
 )
 from covid_model_seiir_pipeline.forecasting.task.postprocessing import (
     MEASURES,
     MISCELLANEOUS,
-    COVARIATES
+    COVARIATES,
 )
 
 

--- a/src/covid_model_seiir_pipeline/forecasting/workflow.py
+++ b/src/covid_model_seiir_pipeline/forecasting/workflow.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 from jobmon.client import BashTask
 
-from covid_model_seiir_pipeline.workflow_template import (
+from covid_model_seiir_pipeline.workflow_tools.template import (
     TaskTemplate,
     WorkflowTemplate
 )

--- a/src/covid_model_seiir_pipeline/regression/main.py
+++ b/src/covid_model_seiir_pipeline/regression/main.py
@@ -34,7 +34,8 @@ def do_beta_regression(app_metadata: cli_tools.Metadata,
 
     # build workflow and launch
     if not preprocess_only:
-        regression_wf = RegressionWorkflow(regression_specification.data.output_root)
+        regression_wf = RegressionWorkflow(regression_specification.data.output_root,
+                                           regression_specification.workflow)
         regression_wf.attach_tasks(n_draws=regression_specification.parameters.n_draws)
         try:
             regression_wf.run()

--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -14,7 +14,7 @@ REGRESSION_JOBS = __RegressionJobs()
 
 class RegressionTaskSpecification(TaskSpecification):
     """Specification of execution parameters for regression tasks."""
-    default_max_runtime_seconds = 3000,
+    default_max_runtime_seconds = 3000
     default_m_mem_free = '2G'
     default_num_cores = 1
 

--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -13,13 +13,14 @@ REGRESSION_JOBS = __RegressionJobs()
 
 
 class RegressionTaskSpecification(TaskSpecification):
+    """Specification of execution parameters for regression tasks."""
     default_max_runtime_seconds = 3000,
     default_m_mem_free = '2G'
     default_num_cores = 1
 
 
 class RegressionWorkflowSpecification(WorkflowSpecification):
-
+    """Specification of execution parameters for regression workflows."""
     tasks = {
         REGRESSION_JOBS.regression: RegressionTaskSpecification,
     }

--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -2,6 +2,11 @@ from dataclasses import dataclass, field
 from typing import Dict, Tuple, List
 
 from covid_model_seiir_pipeline.utilities import Specification, asdict
+from covid_model_seiir_pipeline.workflow_template import TaskSpecification, WorkflowSpecification
+
+
+class RegressionTaskSpecification(TaskSpecification):
+
 
 
 @dataclass

--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -1,12 +1,28 @@
 from dataclasses import dataclass, field
-from typing import Dict, Tuple, List
+from typing import Dict, List, NamedTuple, Tuple
 
 from covid_model_seiir_pipeline.utilities import Specification, asdict
 from covid_model_seiir_pipeline.workflow_template import TaskSpecification, WorkflowSpecification
 
 
-class RegressionTaskSpecification(TaskSpecification):
+class __RegressionJobs(NamedTuple):
+    regression: str = 'regression'
 
+
+REGRESSION_JOBS = __RegressionJobs()
+
+
+class RegressionTaskSpecification(TaskSpecification):
+    default_max_runtime_seconds = 3000,
+    default_m_mem_free = '2G'
+    default_num_cores = 1
+
+
+class RegressionWorkflowSpecification(WorkflowSpecification):
+
+    tasks = {
+        REGRESSION_JOBS.regression: RegressionTaskSpecification,
+    }
 
 
 @dataclass
@@ -69,8 +85,10 @@ class RegressionSpecification(Specification):
     def __init__(self,
                  data: RegressionData,
                  parameters: FitParameters,
-                 covariates: List[CovariateSpecification]):
+                 covariates: List[CovariateSpecification],
+                 workflow: RegressionWorkflowSpecification):
         self._data = data
+        self._workflow = workflow
         self._parameters = parameters
         self._covariates = {c.name: c for c in covariates}
 
@@ -79,6 +97,7 @@ class RegressionSpecification(Specification):
         """Constructs a regression specification from a dictionary."""
         data = RegressionData(**regression_spec_dict.get('data', {}))
         parameters = FitParameters(**regression_spec_dict.get('parameters', {}))
+        workflow = RegressionWorkflowSpecification(**regression_spec_dict.get('workflow', {}))
 
         # covariates
         cov_dicts = regression_spec_dict.get('covariates', {})
@@ -88,12 +107,17 @@ class RegressionSpecification(Specification):
         if not covariates:  # Assume we're generating for a template
             covariates.append(CovariateSpecification())
 
-        return data, parameters, covariates
+        return data, parameters, covariates, workflow
 
     @property
     def data(self) -> RegressionData:
         """The data specification for the regression."""
         return self._data
+
+    @property
+    def workflow(self) -> RegressionWorkflowSpecification:
+        """The workflow specification for the regression."""
+        return self._workflow
 
     @property
     def parameters(self) -> FitParameters:
@@ -109,6 +133,7 @@ class RegressionSpecification(Specification):
         """Converts the specification to a dict."""
         spec = {
             'data': self.data.to_dict(),
+            'workflow': self.workflow.to_dict(),
             'parameters': self.parameters.to_dict(),
             'covariates': {k: v.to_dict() for k, v in self._covariates.items()},
         }

--- a/src/covid_model_seiir_pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/regression/specification.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, NamedTuple, Tuple
 
 from covid_model_seiir_pipeline.utilities import Specification, asdict
-from covid_model_seiir_pipeline.workflow_template import TaskSpecification, WorkflowSpecification
+from covid_model_seiir_pipeline.workflow_tools.specification import TaskSpecification, WorkflowSpecification
 
 
 class __RegressionJobs(NamedTuple):

--- a/src/covid_model_seiir_pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/regression/workflow.py
@@ -1,8 +1,7 @@
 import shutil
 
-from jobmon.client.swarm.executors.base import ExecutorParameters
-
 from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowTemplate
+from covid_model_seiir_pipeline.regression.specification import REGRESSION_JOBS
 
 
 class BetaRegressionTaskTemplate(TaskTemplate):
@@ -17,10 +16,12 @@ class BetaRegressionTaskTemplate(TaskTemplate):
 class RegressionWorkflow(WorkflowTemplate):
 
     workflow_name_template = 'seiir-regression-{version}'
-    task_templates = {'regression': BetaRegressionTaskTemplate()}
+    task_template_classes = {
+        REGRESSION_JOBS.regression: BetaRegressionTaskTemplate
+    }
 
     def attach_tasks(self, n_draws: int):
-        regression_template = self.task_templates['regression']
+        regression_template = self.task_templates[REGRESSION_JOBS.regression]
         for draw_id in range(n_draws):
             task = regression_template.get_task(
                 regression_version=self.version,

--- a/src/covid_model_seiir_pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/regression/workflow.py
@@ -12,12 +12,6 @@ class BetaRegressionTaskTemplate(TaskTemplate):
             "--draw-id {draw_id} " +
             "--regression-version {regression_version} "
     )
-    params = ExecutorParameters(
-        max_runtime_seconds=3000,
-        m_mem_free='2G',
-        num_cores=1,
-        queue='d.q'
-    )
 
 
 class RegressionWorkflow(WorkflowTemplate):

--- a/src/covid_model_seiir_pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/regression/workflow.py
@@ -1,6 +1,6 @@
 import shutil
 
-from covid_model_seiir_pipeline.workflow_template import TaskTemplate, WorkflowTemplate
+from covid_model_seiir_pipeline.workflow_tools.template import TaskTemplate, WorkflowTemplate
 from covid_model_seiir_pipeline.regression.specification import REGRESSION_JOBS
 
 

--- a/src/covid_model_seiir_pipeline/workflow_template.py
+++ b/src/covid_model_seiir_pipeline/workflow_template.py
@@ -1,6 +1,9 @@
 import abc
+from dataclasses import dataclass, field
+import re
 from typing import Dict
 
+from loguru import logger
 from jobmon.client import Workflow, BashTask
 from jobmon.client.swarm.executors.base import ExecutorParameters
 from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
@@ -8,11 +11,66 @@ from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
 from covid_model_seiir_pipeline import utilities
 
 
-class TaskTemplate:
+DEFAULT_PROJECT = 'proj_covid'
+DEFAULT_QUEUE = 'd.q'
+
+
+class TaskSpecification(abc.ABC):
+    name: str
+    default_max_runtime_seconds: int
+    default_m_mem_free: str
+    default_num_cores: int
+
+    def __init__(self, task_specification_dict: Dict):
+        runtime_bounds = [100, 60*60*24]
+        self.max_runtime_seconds: int = task_specification_dict.pop('max_runtime_seconds',
+                                                                    self.default_max_runtime_seconds)
+        if not runtime_bounds[0] <= self.max_runtime_seconds <= runtime_bounds[1]:
+            raise ValueError(f'Invalid max runtime for {self.name}: {self.max_runtime_seconds}. '
+                             f'Max runtime must be in the range {runtime_bounds}.')
+
+        mem_re = re.compile('\\d+[G]')
+        mem_bounds_gb = [1, 1000]
+        self.m_mem_free: str = task_specification_dict.pop('m_mem_free',
+                                                      self.default_m_mem_free)
+        if not mem_re.match(self.m_mem_free):
+            raise ValueError('Memory request is expected to be in the format "XG" where X is an integer. '
+                             f'You provided {self.m_mem_free} for {self.name}.')
+        if not mem_bounds_gb[1] <= int(self.m_mem_free[:-1]) <= mem_bounds_gb[1]:
+            raise ValueError(f'Invalid max memory for {self.name}: {self.m_mem_free}. ',
+                             f'Max memory must be in the range {mem_bounds_gb}G.')
+
+        num_core_bounds = [1, 30]
+        self.num_cores: int = task_specification_dict.pop('num_cores',
+                                                     self.default_num_cores)
+        if not num_core_bounds[0] <= self.num_cores <= num_core_bounds[1]:
+            raise ValueError(f'Invalid num cores for {self.name}: {self.num_cores}. '
+                             f'Num cores must be in the range {num_core_bounds}')
+
+        allowed_queues = ['d.q', 'all.q', 'long.q']
+        self.queue: str = task_specification_dict.pop('queue', DEFAULT_QUEUE)
+        if self.queue not in allowed_queues:
+            raise ValueError(f'Invalid queue for {self.name}: {self.queue}. '
+                             f'Queue must be one of {allowed_queues}.')
+
+        if task_specification_dict:
+            logger.warning(f'Unknown task options specified for {self.name}: {task_specification_dict}. '
+                           f'These options will be ignored.')
+
+    def to_dict(self):
+        return {'max_runtime_seconds': self.max_runtime_seconds,
+                'm_mem_free': self.m_mem_free,
+                'num_cores': self.num_cores,
+                'queue': self.queue}
+
+
+class TaskTemplate(abc.ABC):
 
     task_name_template: str = None
     command_template: str = None
-    params: ExecutorParameters = None
+
+    def __init__(self, task_specification: TaskSpecification):
+        self.params = ExecutorParameters(**task_specification.to_dict())
 
     def get_task(self, *_, **kwargs) -> BashTask:
         task = BashTask(
@@ -24,13 +82,24 @@ class TaskTemplate:
         return task
 
 
-class WorkflowTemplate:
+@dataclass
+class WorkflowSpecification:
+    project: str = field(default='proj_covid')
+    tasks: Dict[str, TaskSpecification] = field(default_factory=dict)
+
+    def to_dict(self):
+        return {'project': self.project,
+                'tasks': {k: v.to_dict() for k, v in self.tasks}}
+
+
+class WorkflowTemplate(abc.ABC):
 
     workflow_name_template: str = None
     task_templates: Dict[str, TaskTemplate] = None
 
-    def __init__(self, version: str):
+    def __init__(self, version: str, workflow_specification: WorkflowSpecification):
         self.version = version
+        self.task_templates = self.build_task_templates(workflow_specification.tasks)
         stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
 
         self.workflow = Workflow(
@@ -43,10 +112,14 @@ class WorkflowTemplate:
         )
 
     @abc.abstractmethod
-    def attach_tasks(self, *args, **kwargs):
+    def build_task_templates(self, task_specifications: Dict[str, TaskSpecification]) -> Dict[str, TaskTemplate]:
         pass
 
-    def run(self):
+    @abc.abstractmethod
+    def attach_tasks(self, *args, **kwargs) -> None:
+        pass
+
+    def run(self) -> None:
         execution_status = self.workflow.run()
         if execution_status != DagExecutionStatus.SUCCEEDED:
             raise RuntimeError("Workflow failed. Check database or logs for errors")

--- a/src/covid_model_seiir_pipeline/workflow_tools/specification.py
+++ b/src/covid_model_seiir_pipeline/workflow_tools/specification.py
@@ -99,7 +99,8 @@ class TaskSpecification:
         """Coerce the specification to a dict for display or write to disk."""
         return {'max_runtime_seconds': self.max_runtime_seconds,
                 'm_mem_free': self.m_mem_free,
-                'num_cores': self.num_cores}
+                'num_cores': self.num_cores,
+                'queue': self.queue}
 
     def __repr__(self):
         return f'{self.name}({", ".join([f"{k}={v}" for k, v in self.to_dict().items()])})'

--- a/src/covid_model_seiir_pipeline/workflow_tools/specification.py
+++ b/src/covid_model_seiir_pipeline/workflow_tools/specification.py
@@ -12,7 +12,7 @@ DEFAULT_QUEUE = 'd.q'
 _TaskSpecDict = Dict[str, Union[str, int]]
 
 
-class TaskSpecification(abc.ABC):
+class TaskSpecification:
     """Validation wrapper for specifying task execution parameters.
 
     This class is intended to outline the parameter space for task
@@ -26,9 +26,16 @@ class TaskSpecification(abc.ABC):
     the values in the `validate` method of this class.
 
     """
+    # Class variables meant to be overridden by subclasses.
     default_max_runtime_seconds: int
     default_m_mem_free: str
     default_num_cores: int
+
+    # Constants for all tasks.
+    _runtime_bounds = [100, 60 * 60 * 24]
+    _mem_re = re.compile('\\d+[G]')
+    _mem_bounds_gb = [1, 1000]
+    _num_core_bounds = [1, 30]
 
     def __init__(self, task_specification_dict: _TaskSpecDict):
         self.name = self.__class__.__name__
@@ -45,26 +52,48 @@ class TaskSpecification(abc.ABC):
             logger.warning(f'Unknown task options specified for {self.name}: {task_specification_dict}. '
                            f'These options will be ignored.')
 
+    def __init_subclass__(cls, **kwargs):
+        name = cls.__name__
+
+        for attr in ['default_max_runtime_seconds', 'default_m_mem_free', 'default_num_cores']:
+            if getattr(cls, attr) is None:
+                raise AttributeError(f'No default value provided for {attr} for task template subclass {name}. '
+                                     'Check your class definition.')
+
+        if not cls._runtime_bounds[0] <= cls.default_max_runtime_seconds <= cls._runtime_bounds[1]:
+            raise AttributeError(f'Invalid default max runtime for {name}: {cls.default_max_runtime_seconds}. '
+                                 f'Max runtime must be in the range {cls._runtime_bounds}.'
+                                 'Check your class definition.')
+
+        if not cls._mem_re.match(cls.default_m_mem_free):
+            raise AttributeError('Memory request is expected to be in the format "XG" where X is an integer. '
+                                 f'You provided {cls.default_m_mem_free} for {name}.')
+        if not cls._mem_bounds_gb[0] <= int(cls.default_m_mem_free[:-1]) <= cls._mem_bounds_gb[1]:
+            raise AttributeError(f'Invalid default max memory for {name}: {cls.default_m_mem_free}. ',
+                                 f'Max memory must be in the range {cls._mem_bounds_gb}G. '
+                                 'Check your class definition.')
+
+        if not cls._num_core_bounds[0] <= cls.default_num_cores <= cls._num_core_bounds[1]:
+            raise AttributeError(f'Invalid num cores for {name}: {cls.default_num_cores}. '
+                                 f'Num cores must be in the range {cls._num_core_bounds}l '
+                                 'Check your class definition.')
+
     def validate(self):
         """Checks specification against some baseline constraints."""
-        runtime_bounds = [100, 60*60*24]
-        if not runtime_bounds[0] <= self.max_runtime_seconds <= runtime_bounds[1]:
+        if not self._runtime_bounds[0] <= self.max_runtime_seconds <= self._runtime_bounds[1]:
             raise ValueError(f'Invalid max runtime for {self.name}: {self.max_runtime_seconds}. '
-                             f'Max runtime must be in the range {runtime_bounds}.')
+                             f'Max runtime must be in the range {self._runtime_bounds}.')
 
-        mem_re = re.compile('\\d+[G]')
-        mem_bounds_gb = [1, 1000]
-        if not mem_re.match(self.m_mem_free):
+        if not self._mem_re.match(self.m_mem_free):
             raise ValueError('Memory request is expected to be in the format "XG" where X is an integer. '
                              f'You provided {self.m_mem_free} for {self.name}.')
-        if not mem_bounds_gb[0] <= int(self.m_mem_free[:-1]) <= mem_bounds_gb[1]:
+        if not self._mem_bounds_gb[0] <= int(self.m_mem_free[:-1]) <= self._mem_bounds_gb[1]:
             raise ValueError(f'Invalid max memory for {self.name}: {self.m_mem_free}. ',
-                             f'Max memory must be in the range {mem_bounds_gb}G.')
+                             f'Max memory must be in the range {self._mem_bounds_gb}G.')
 
-        num_core_bounds = [1, 30]
-        if not num_core_bounds[0] <= self.num_cores <= num_core_bounds[1]:
+        if not self._num_core_bounds[0] <= self.num_cores <= self._num_core_bounds[1]:
             raise ValueError(f'Invalid num cores for {self.name}: {self.num_cores}. '
-                             f'Num cores must be in the range {num_core_bounds}')
+                             f'Num cores must be in the range {self._num_core_bounds}')
 
     def to_dict(self) -> Dict[str, Union[str, int]]:
         """Coerce the specification to a dict for display or write to disk."""

--- a/src/covid_model_seiir_pipeline/workflow_tools/specification.py
+++ b/src/covid_model_seiir_pipeline/workflow_tools/specification.py
@@ -1,15 +1,9 @@
-"""Primitives for construction jobmon workflows and workflow specifications."""
-
+"""Primitives for construction jobmon workflow specifications."""
 import abc
 import re
 from typing import Dict, Type, TypeVar, Union
 
 from loguru import logger
-from jobmon.client import Workflow, BashTask
-from jobmon.client.swarm.executors.base import ExecutorParameters
-from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
-
-from covid_model_seiir_pipeline import utilities
 
 
 DEFAULT_PROJECT = 'proj_covid'
@@ -85,36 +79,6 @@ class TaskSpecification(abc.ABC):
 TTaskSpecification = TypeVar('TTaskSpecification', bound=TaskSpecification)
 
 
-class TaskTemplate(abc.ABC):
-    """Factory class for a parameterized task.
-
-    Subclasses are intended to inherit and provide string templates for the
-    class variables ``task_name_template`` which will construct cluster
-    job names from the task args and ``command_template`` which will
-    resolve the task args into a job executable by bash.
-
-    """
-
-    task_name_template: str
-    command_template: str
-
-    def __init__(self, task_specification: TaskSpecification):
-        self.params = ExecutorParameters(**task_specification.to_dict())
-
-    def get_task(self, *_, **kwargs) -> BashTask:
-        """Resolve job arguments into a bash executable task for jobmon."""
-        task = BashTask(
-            command=self.command_template.format(**kwargs),
-            name=self.task_name_template.format(**kwargs),
-            executor_parameters=self.params,
-            max_attempts=1
-        )
-        return task
-
-
-TTaskTemplate = TypeVar('TTaskTemplate', bound=TaskTemplate)
-
-
 class WorkflowSpecification(abc.ABC):
     """Validation wrapper for specifying workflow execution parameters.
 
@@ -182,63 +146,3 @@ class WorkflowSpecification(abc.ABC):
 
     def __repr__(self):
         return f'{self.name}({", ".join([f"{k}={v}" for k, v in self.to_dict().items()])})'
-
-
-class WorkflowTemplate(abc.ABC):
-    """Factory for building and running workflows from specifications.
-
-    Subclasses are intended to inherit and provide a string template for the
-    class variable ``workflow_name_template`` which takes an output version
-    string and maps it to a unique workflow name, and a dictionary mapping
-    task type names to concrete subclasses of the ``TaskTemplate`` base
-    class as the ``task_template_classes`` class variable. This mapping
-    is tightly coupled with the ``tasks`` mapping of the associated
-    workflow specification (ie, they should have exactly the same keys).
-
-    When instantiated, the ``WorkflowTemplate`` subclasses will
-    produce a jobmon workflow from the provided workflow specification,
-    set up output logging directories, and produce concrete templates for
-    workflow tasks.
-
-    Subclass implementers must provide an implementation of ``attach_tasks``
-    which takes relevant model parameters as arguments and builds and attaches
-    an appropriate task dag to the jobmon workflow.
-
-    """
-
-    workflow_name_template: str = None
-    task_template_classes: Dict[str, Type[TTaskTemplate]]
-
-    def __init__(self, version: str, workflow_specification: WorkflowSpecification):
-        self.version = version
-        assert workflow_specification.tasks.keys() == self.task_template_classes.keys()
-        self.task_templates = self.build_task_templates(workflow_specification.tasks)
-        stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
-
-        self.workflow = Workflow(
-            workflow_args=self.workflow_name_template.format(version=version),
-            project=workflow_specification.project,
-            stderr=stderr,
-            stdout=stdout,
-            seconds_until_timeout=60*60*24,
-            resume=True
-        )
-
-    def build_task_templates(self, task_specifications: Dict[str, TaskSpecification]) -> Dict[str, TaskTemplate]:
-        """Parses task specifications into task templates."""
-        task_templates = {}
-        for task_name, task_specification in task_specifications.items():
-            task_templates[task_name] = self.task_template_classes[task_name](task_specification.to_dict())
-        return task_templates
-
-    @abc.abstractmethod
-    def attach_tasks(self, *args, **kwargs) -> None:
-        """Turn model arguments into jobmon workflow tasks."""
-        pass
-
-    def run(self) -> None:
-        """Execute the constructed workflow."""
-        execution_status = self.workflow.run()
-        if execution_status != DagExecutionStatus.SUCCEEDED:
-            raise RuntimeError("Workflow failed. Check database or logs for errors")
-

--- a/src/covid_model_seiir_pipeline/workflow_tools/template.py
+++ b/src/covid_model_seiir_pipeline/workflow_tools/template.py
@@ -87,7 +87,7 @@ class WorkflowTemplate(abc.ABC):
         """Parses task specifications into task templates."""
         task_templates = {}
         for task_name, task_specification in task_specifications.items():
-            task_templates[task_name] = self.task_template_classes[task_name](task_specification.to_dict())
+            task_templates[task_name] = self.task_template_classes[task_name](task_specification)
         return task_templates
 
     @abc.abstractmethod

--- a/src/covid_model_seiir_pipeline/workflow_tools/template.py
+++ b/src/covid_model_seiir_pipeline/workflow_tools/template.py
@@ -1,0 +1,102 @@
+"""Primitives for construction jobmon workflows."""
+import abc
+from typing import Dict, Type, TypeVar
+
+from jobmon.client import Workflow, BashTask
+from jobmon.client.swarm.executors.base import ExecutorParameters
+from jobmon.client.swarm.workflow.task_dag import DagExecutionStatus
+
+from covid_model_seiir_pipeline import utilities
+from covid_model_seiir_pipeline.workflow_tools.specification import (
+    TaskSpecification,
+    WorkflowSpecification
+)
+
+
+class TaskTemplate(abc.ABC):
+    """Factory class for a parameterized task.
+
+    Subclasses are intended to inherit and provide string templates for the
+    class variables ``task_name_template`` which will construct cluster
+    job names from the task args and ``command_template`` which will
+    resolve the task args into a job executable by bash.
+
+    """
+
+    task_name_template: str
+    command_template: str
+
+    def __init__(self, task_specification: TaskSpecification):
+        self.params = ExecutorParameters(**task_specification.to_dict())
+
+    def get_task(self, *_, **kwargs) -> BashTask:
+        """Resolve job arguments into a bash executable task for jobmon."""
+        task = BashTask(
+            command=self.command_template.format(**kwargs),
+            name=self.task_name_template.format(**kwargs),
+            executor_parameters=self.params,
+            max_attempts=1
+        )
+        return task
+
+
+TTaskTemplate = TypeVar('TTaskTemplate', bound=TaskTemplate)
+
+
+class WorkflowTemplate(abc.ABC):
+    """Factory for building and running workflows from specifications.
+
+    Subclasses are intended to inherit and provide a string template for the
+    class variable ``workflow_name_template`` which takes an output version
+    string and maps it to a unique workflow name, and a dictionary mapping
+    task type names to concrete subclasses of the ``TaskTemplate`` base
+    class as the ``task_template_classes`` class variable. This mapping
+    is tightly coupled with the ``tasks`` mapping of the associated
+    workflow specification (ie, they should have exactly the same keys).
+
+    When instantiated, the ``WorkflowTemplate`` subclasses will
+    produce a jobmon workflow from the provided workflow specification,
+    set up output logging directories, and produce concrete templates for
+    workflow tasks.
+
+    Subclass implementers must provide an implementation of ``attach_tasks``
+    which takes relevant model parameters as arguments and builds and attaches
+    an appropriate task dag to the jobmon workflow.
+
+    """
+
+    workflow_name_template: str = None
+    task_template_classes: Dict[str, Type[TTaskTemplate]]
+
+    def __init__(self, version: str, workflow_specification: WorkflowSpecification):
+        self.version = version
+        assert workflow_specification.tasks.keys() == self.task_template_classes.keys()
+        self.task_templates = self.build_task_templates(workflow_specification.tasks)
+        stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
+
+        self.workflow = Workflow(
+            workflow_args=self.workflow_name_template.format(version=version),
+            project=workflow_specification.project,
+            stderr=stderr,
+            stdout=stdout,
+            seconds_until_timeout=60*60*24,
+            resume=True
+        )
+
+    def build_task_templates(self, task_specifications: Dict[str, TaskSpecification]) -> Dict[str, TaskTemplate]:
+        """Parses task specifications into task templates."""
+        task_templates = {}
+        for task_name, task_specification in task_specifications.items():
+            task_templates[task_name] = self.task_template_classes[task_name](task_specification.to_dict())
+        return task_templates
+
+    @abc.abstractmethod
+    def attach_tasks(self, *args, **kwargs) -> None:
+        """Turn model arguments into jobmon workflow tasks."""
+        pass
+
+    def run(self) -> None:
+        """Execute the constructed workflow."""
+        execution_status = self.workflow.run()
+        if execution_status != DagExecutionStatus.SUCCEEDED:
+            raise RuntimeError("Workflow failed. Check database or logs for errors")

--- a/src/covid_model_seiir_pipeline/workflow_tools/template.py
+++ b/src/covid_model_seiir_pipeline/workflow_tools/template.py
@@ -71,7 +71,7 @@ class WorkflowTemplate(abc.ABC):
     def __init__(self, version: str, workflow_specification: WorkflowSpecification):
         self.version = version
         assert workflow_specification.tasks.keys() == self.task_template_classes.keys()
-        self.task_templates = self.build_task_templates(workflow_specification.tasks)
+        self.task_templates = self.build_task_templates(workflow_specification.task_specifications)
         stdout, stderr = utilities.make_log_dirs(version, prefix='jobmon')
 
         self.workflow = Workflow(


### PR DESCRIPTION
The main point of this PR is to allow specification of the queue, project, and task execution parameters for the SEIR pipeline in the model specification files.  To do this, I've introduced a pair of specification abstractions that do the same work as the other specifications: providing sensible defaults and validating specification parameters.  One for the tasks and one for the overall workflow.

I've also done some refinement of the existing abstractions around the actual workflow and workflow task implementations to reduce some boilerplate and to make use of the new specification abstractions.
