### PR TITLE
Add entry point for running all SEIIR pipeline stages.

### DIFF
--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -24,134 +24,6 @@ def seiir():
 
 
 @seiir.command()
-@click.argument('regression_specification',
-                type=click.Path(exists=True, dir_okay=False))
-@click.argument('forecast_specification',
-                type=click.Path(exists=True, dir_okay=False))
-@click.argument('postprocessing_specification',
-                type=click.Path(exists=True, dir_okay=False))
-@click.option('-p', '--production-tag',
-              type=click.STRING,
-              help='Tags this run as a production run.')
-@click.option('-b', '--mark-best',
-              is_flag=True,
-              help='Mark this run as "best"')
-@cli_tools.add_verbose_and_with_debugger
-def run_all(regression_specification,
-            forecast_specification,
-            postprocessing_specification,
-            mark_best, production_tag,
-            verbose, with_debugger):
-    #####################
-    # Do the regression #
-    #####################
-    cli_tools.configure_logging_to_terminal(verbose)
-
-    regression_spec = RegressionSpecification.from_path(regression_specification)
-
-    # Resolve CLI overrides and specification values with defaults into
-    # final run arguments.
-    infection_root = utilities.get_input_root(None,
-                                              regression_spec.data.infection_version,
-                                              paths.INFECTIONATOR_OUTPUTS)
-    covariates_root = utilities.get_input_root(None,
-                                               regression_spec.data.covariate_version,
-                                               paths.SEIR_COVARIATES_OUTPUT_ROOT)
-    locations_set_version_id, location_set_file = utilities.get_location_info(
-        None,
-        regression_spec.data.location_set_version_id,
-        regression_spec.data.location_set_file
-    )
-    output_root = paths.SEIR_REGRESSION_OUTPUTS
-    cli_tools.setup_directory_structure(output_root, with_production=True)
-    run_directory = cli_tools.make_run_directory(output_root)
-
-    # Make the regression specification consistent with the resolved arguments
-    # and dump to disk.
-    regression_spec.data.infection_version = str(infection_root)
-    regression_spec.data.covariate_version = str(covariates_root)
-    regression_spec.data.location_set_version_id = locations_set_version_id
-    regression_spec.data.location_set_file = location_set_file
-    regression_spec.data.output_root = str(run_directory)
-
-    regression_run_metadata = cli_tools.RunMetadata()
-
-    for key, input_root in zip(['infectionator_metadata', 'covariates_metadata'],
-                               [infection_root, covariates_root]):
-        regression_run_metadata.update_from_path(key, input_root / paths.METADATA_FILE_NAME)
-    regression_run_metadata['output_path'] = str(run_directory)
-    regression_run_metadata['regression_specification'] = regression_spec.to_dict()
-
-    cli_tools.configure_logging_to_files(run_directory)
-    main = cli_tools.monitor_application(do_beta_regression,
-                                         logger, with_debugger)
-    app_metadata, _ = main(regression_spec, False)
-
-    cli_tools.finish_application(regression_run_metadata, app_metadata,
-                                 run_directory, mark_best, production_tag)
-
-    logger.info('Regression finished. Starting forecast.')
-    logger.remove()  # Get rid of all handlers so we get clean forecast logs.
-    cli_tools.configure_logging_to_terminal(verbose)
-
-    forecast_spec = ForecastSpecification.from_path(forecast_specification)
-
-    output_root = paths.SEIR_FORECAST_OUTPUTS
-    cli_tools.setup_directory_structure(output_root, with_production=True)
-    run_directory = cli_tools.make_run_directory(output_root)
-
-    forecast_spec.data.regression_version = regression_spec.data.output_root
-    forecast_spec.data.covariate_version = regression_spec.data.covariate_version
-    forecast_spec.data.output_root = str(run_directory)
-
-    forecast_run_metadata = cli_tools.RunMetadata()
-    forecast_run_metadata.update_from_path('regression_metadata',
-                                           Path(forecast_spec.data.regression_version) / paths.METADATA_FILE_NAME)
-    forecast_run_metadata['output_path'] = str(run_directory)
-    forecast_run_metadata['forecast_specification'] = forecast_spec.to_dict()
-
-    cli_tools.configure_logging_to_files(run_directory)
-    main = cli_tools.monitor_application(do_beta_forecast,
-                                         logger, with_debugger)
-    app_metadata, _ = main(forecast_spec, False)
-
-    cli_tools.finish_application(forecast_run_metadata, app_metadata,
-                                 run_directory, mark_best, production_tag)
-
-    logger.info('Forecast finished. Starting postprocessing.')
-    logger.remove()  # Get rid of all handlers so we get clean postprocessing logs.
-
-    cli_tools.configure_logging_to_terminal(verbose)
-
-    postprocessing_spec = PostprocessingSpecification.from_path(postprocessing_specification)
-
-    output_root = paths.SEIR_FINAL_OUTPUTS
-    cli_tools.setup_directory_structure(output_root, with_production=True)
-    run_directory = cli_tools.make_run_directory(output_root)
-
-    postprocessing_spec.data.forecast_version = forecast_spec.data.output_root
-    postprocessing_spec.data.output_root = str(run_directory)
-
-    postprocessing_run_metadata = cli_tools.RunMetadata()
-    postprocessing_run_metadata.update_from_path(
-        'forecast_metadata',
-        Path(postprocessing_spec.data.forecast_version) / paths.METADATA_FILE_NAME
-    )
-    postprocessing_run_metadata['output_path'] = str(run_directory)
-    postprocessing_run_metadata['postprocessing_specification'] = postprocessing_spec.to_dict()
-
-    cli_tools.configure_logging_to_files(run_directory)
-    main = cli_tools.monitor_application(do_postprocessing,
-                                         logger, with_debugger)
-    app_metadata, _ = main(postprocessing_spec, False)
-
-    cli_tools.finish_application(postprocessing_run_metadata, app_metadata,
-                                 run_directory, mark_best, production_tag)
-
-    logger.info('All stages complete!')
-
-
-@seiir.command()
 @cli_tools.pass_run_metadata()
 @click.argument('regression_specification',
                 type=click.Path(exists=True, dir_okay=False))
@@ -339,6 +211,154 @@ def postprocess(run_metadata,
 
     logger.info('**Done**')
 
+
+@seiir.command()
+@cli_tools.pass_run_metadata()
+@click.argument('regression_specification',
+                type=click.Path(exists=True, dir_okay=False))
+@click.argument('forecast_specification',
+                type=click.Path(exists=True, dir_okay=False))
+@click.argument('postprocessing_specification',
+                type=click.Path(exists=True, dir_okay=False))
+@click.option('-p', '--production-tag',
+              type=click.STRING,
+              help='Tags this run as a production run.')
+@click.option('-b', '--mark-best',
+              is_flag=True,
+              help='Mark this run as "best"')
+@cli_tools.add_verbose_and_with_debugger
+def run_all(run_metadata,
+            regression_specification, forecast_specification, postprocessing_specification,
+            mark_best, production_tag,
+            verbose, with_debugger):
+    """Run all stages of the SEIIR pipeline.
+
+    This application is expected to be run in production only and provides
+    no user-level interface for specifying output paths. The `data` block
+    of the regression specification can specify a specific path for infection
+    data and covariate data, but all output paths and downstream input
+    paths will be inferred automatically.
+    """
+    #####################
+    # Do the regression #
+    #####################
+    cli_tools.configure_logging_to_terminal(verbose)
+
+    regression_spec = RegressionSpecification.from_path(regression_specification)
+
+    # The regression might provide specific paths here. Downstream will
+    # fill automatically.
+    infection_root = utilities.get_input_root(None,
+                                              regression_spec.data.infection_version,
+                                              paths.INFECTIONATOR_OUTPUTS)
+    covariates_root = utilities.get_input_root(None,
+                                               regression_spec.data.covariate_version,
+                                               paths.SEIR_COVARIATES_OUTPUT_ROOT)
+    locations_set_version_id, location_set_file = utilities.get_location_info(
+        None,
+        regression_spec.data.location_set_version_id,
+        regression_spec.data.location_set_file
+    )
+    # Override the output directories.  This is production specific.
+    output_root = paths.SEIR_REGRESSION_OUTPUTS
+    cli_tools.setup_directory_structure(output_root, with_production=True)
+    run_directory = cli_tools.make_run_directory(output_root)
+
+    # Make the regression specification consistent with the resolved arguments
+    # and dump to disk.
+    regression_spec.data.infection_version = str(infection_root)
+    regression_spec.data.covariate_version = str(covariates_root)
+    regression_spec.data.location_set_version_id = locations_set_version_id
+    regression_spec.data.location_set_file = location_set_file
+    regression_spec.data.output_root = str(run_directory)
+
+    # Build our own run metadata since the injected version is shared across the
+    # three pipeline stages.
+    regression_run_metadata = cli_tools.RunMetadata().update(run_metadata.to_dict())
+
+    for key, input_root in zip(['infectionator_metadata', 'covariates_metadata'],
+                               [infection_root, covariates_root]):
+        regression_run_metadata.update_from_path(key, input_root / paths.METADATA_FILE_NAME)
+    regression_run_metadata['output_path'] = str(run_directory)
+    regression_run_metadata['regression_specification'] = regression_spec.to_dict()
+
+    cli_tools.configure_logging_to_files(run_directory)
+    main = cli_tools.monitor_application(do_beta_regression,
+                                         logger, with_debugger)
+    app_metadata, _ = main(regression_spec, False)
+
+    cli_tools.finish_application(regression_run_metadata, app_metadata,
+                                 run_directory, mark_best, production_tag)
+
+    logger.info('Regression finished. Starting forecast.')
+
+    ###################
+    # Do the forecast #
+    ###################
+
+    logger.remove()  # Get rid of all handlers so we get clean forecast logs.
+    cli_tools.configure_logging_to_terminal(verbose)
+
+    forecast_spec = ForecastSpecification.from_path(forecast_specification)
+
+    output_root = paths.SEIR_FORECAST_OUTPUTS
+    cli_tools.setup_directory_structure(output_root, with_production=True)
+    run_directory = cli_tools.make_run_directory(output_root)
+
+    forecast_spec.data.regression_version = regression_spec.data.output_root
+    forecast_spec.data.covariate_version = regression_spec.data.covariate_version
+    forecast_spec.data.output_root = str(run_directory)
+
+    forecast_run_metadata = cli_tools.RunMetadata().update(run_metadata.to_dict())
+    forecast_run_metadata.update_from_path('regression_metadata',
+                                           Path(forecast_spec.data.regression_version) / paths.METADATA_FILE_NAME)
+    forecast_run_metadata['output_path'] = str(run_directory)
+    forecast_run_metadata['forecast_specification'] = forecast_spec.to_dict()
+
+    cli_tools.configure_logging_to_files(run_directory)
+    main = cli_tools.monitor_application(do_beta_forecast,
+                                         logger, with_debugger)
+    app_metadata, _ = main(forecast_spec, False)
+
+    cli_tools.finish_application(forecast_run_metadata, app_metadata,
+                                 run_directory, mark_best, production_tag)
+
+    logger.info('Forecast finished. Starting postprocessing.')
+
+    #########################
+    # Do the postprocessing #
+    #########################
+
+    logger.remove()  # Get rid of all handlers so we get clean postprocessing logs.
+
+    cli_tools.configure_logging_to_terminal(verbose)
+
+    postprocessing_spec = PostprocessingSpecification.from_path(postprocessing_specification)
+
+    output_root = paths.SEIR_FINAL_OUTPUTS
+    cli_tools.setup_directory_structure(output_root, with_production=True)
+    run_directory = cli_tools.make_run_directory(output_root)
+
+    postprocessing_spec.data.forecast_version = forecast_spec.data.output_root
+    postprocessing_spec.data.output_root = str(run_directory)
+
+    postprocessing_run_metadata = cli_tools.RunMetadata().update(run_metadata.to_dict())
+    postprocessing_run_metadata.update_from_path(
+        'forecast_metadata',
+        Path(postprocessing_spec.data.forecast_version) / paths.METADATA_FILE_NAME
+    )
+    postprocessing_run_metadata['output_path'] = str(run_directory)
+    postprocessing_run_metadata['postprocessing_specification'] = postprocessing_spec.to_dict()
+
+    cli_tools.configure_logging_to_files(run_directory)
+    main = cli_tools.monitor_application(do_postprocessing,
+                                         logger, with_debugger)
+    app_metadata, _ = main(postprocessing_spec, False)
+
+    cli_tools.finish_application(postprocessing_run_metadata, app_metadata,
+                                 run_directory, mark_best, production_tag)
+
+    logger.info('All stages complete!')
 
 
 @seiir.command()


### PR DESCRIPTION
This is mostly a cut and paste version of a full pipeline run application with a bit of wiring to make things work as expected.

The main intention here is to give the prod staff the ability to launch the run and then sign off and come back to results in the AM rather than needing to babysit through the stages.  With that in mind, all the custom I/O path management has been stripped out and some wiring together of the stages is done by updating specification arguments from previous stages.

I spent about 15 minutes looking at how to get rid of some of the boilerplate, but there are a couple of tough cleave points and I don't think it's worthwhile digging in right now.  

