### PR TITLE
Collijk/refactor/cli tech debt

### DIFF
--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -342,7 +342,7 @@ def _do_regression(run_metadata: cli_tools.RunMetadata,
             False,
         ),
     }
-    cli_tools.resolve_version_info(regression_spec, run_metadata, input_versions)
+    regression_spec, run_metadata = cli_tools.resolve_version_info(regression_spec, run_metadata, input_versions)
 
     locations_set_version_id, location_set_file = cli_tools.get_location_info(
         location_specification,
@@ -398,7 +398,7 @@ def _do_forecast(run_metadata: cli_tools.RunMetadata,
             True,
         ),
     }
-    cli_tools.resolve_version_info(forecast_spec, run_metadata, input_versions)
+    forecast_spec, run_metadata = cli_tools.resolve_version_info(forecast_spec, run_metadata, input_versions)
 
     output_root = cli_tools.get_output_root(output_root,
                                             forecast_spec.data.output_root)

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -327,7 +327,7 @@ def _do_regression(run_metadata: cli_tools.RunMetadata,
             'infectionator_metadata',
             True,
         ),
-        'covariates_version': cli_tools.VersionInfo(
+        'covariate_version': cli_tools.VersionInfo(
             covariates_version,
             regression_spec.data.covariate_version,
             paths.SEIR_COVARIATES_OUTPUT_ROOT,
@@ -390,7 +390,7 @@ def _do_forecast(run_metadata: cli_tools.RunMetadata,
             'regression_metadata',
             True,
         ),
-        'covariates_version': cli_tools.VersionInfo(
+        'covariate_version': cli_tools.VersionInfo(
             covariates_version,
             forecast_spec.data.covariate_version,
             paths.SEIR_COVARIATES_OUTPUT_ROOT,

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/__init__.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/__init__.py
@@ -38,6 +38,8 @@ from covid_model_seiir_pipeline.lib.cli_tools.decorators import (
     add_preprocess_only,
 )
 from covid_model_seiir_pipeline.lib.cli_tools.utilities import (
+    VersionInfo,
+    resolve_version_info,
     handle_exceptions,
     get_input_root,
     get_output_root,

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/utilities.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/utilities.py
@@ -32,6 +32,7 @@ def resolve_version_info(specification, run_metadata: cli_tools.RunMetadata, inp
         input_root = get_input_root(version_info.cli_arg, version_info.spec_arg, version_info.default)
         setattr(specification.data, version_key, str(input_root))
         run_metadata.update_from_path(version_info.metadata_key, input_root / paths.METADATA_FILE_NAME)
+    return specification, run_metadata
 
 
 def handle_exceptions(func: Callable, logger: Any, with_debugger: bool) -> Callable:

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/utilities.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/utilities.py
@@ -22,11 +22,10 @@ def resolve_version_info(specification, run_metadata: cli_tools.RunMetadata, inp
     """Resolves cli args, spec values, and defaults and makes the
     specification and metadata consistent.
 
-    I don't love that this mutates the args rather than returning values, but
-    I don't have a clever, clean solution.
-
     """
     for version_key, version_info in input_versions.items():
+        if not hasattr(specification.data, version_key):
+            raise TypeError(f'Invalid key {version_key} for specification data {specification.data}.')
         if not (version_info.cli_arg or version_info.spec_arg or version_info.allow_default):
             continue
         input_root = get_input_root(version_info.cli_arg, version_info.spec_arg, version_info.default)

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/utilities.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/utilities.py
@@ -1,9 +1,37 @@
 from bdb import BdbQuit
 import functools
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Union
 
 from covid_shared import cli_tools, paths
+
+
+MaybePathLike = Union[str, Path, None]
+
+
+class VersionInfo(NamedTuple):
+    """Tiny struct for processing input versions from cli args and specs."""
+    cli_arg: MaybePathLike
+    spec_arg: MaybePathLike
+    default: MaybePathLike
+    metadata_key: str
+    allow_default: bool
+
+
+def resolve_version_info(specification, run_metadata: cli_tools.RunMetadata, input_versions: Dict[str, VersionInfo]):
+    """Resolves cli args, spec values, and defaults and makes the
+    specification and metadata consistent.
+
+    I don't love that this mutates the args rather than returning values, but
+    I don't have a clever, clean solution.
+
+    """
+    for version_key, version_info in input_versions.items():
+        if not (version_info.cli_arg or version_info.spec_arg or version_info.allow_default):
+            continue
+        input_root = get_input_root(version_info.cli_arg, version_info.spec_arg, version_info.default)
+        setattr(specification.data, version_key, str(input_root))
+        run_metadata.update_from_path(version_info.metadata_key, input_root / paths.METADATA_FILE_NAME)
 
 
 def handle_exceptions(func: Callable, logger: Any, with_debugger: bool) -> Callable:


### PR DESCRIPTION
This refactors the cli.py to use some shared functions, which I didn't have time to do when I put in the run_all command.  This significantly reduces code duplication, which is always nice.