### PR TITLE
Collijk/feature/hospital correction factors regression stage

### DIFF
--- a/specification_templates/counties/regression.yaml
+++ b/specification_templates/counties/regression.yaml
@@ -1,6 +1,8 @@
 data:
   infection_version: '2021_01_15.01'
   covariate_version: '2021_01_14.02'
+  mortality_rate_version: 'best'
+  hospital_fatality_ratio_version: 'best'
   coefficient_version: '2021_01_13.06'
   location_set_version_id: ''
   location_set_file: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/location_metadata_815.csv'
@@ -13,6 +15,10 @@ workflow:
       max_runtime_seconds: 3000
       m_mem_free: '2G'
       num_cores: 1
+    hospital_correction_factors:
+      max_runtime_seconds: 3000
+      m_mem_free: '2G'
+      num_cores: 1
 regression_parameters:
   n_draws: 1000
   day_shift: [0, 8]
@@ -22,6 +28,23 @@ regression_parameters:
   gamma2: [0.3333, 1.0]
   solver_dt: 0.1
   sequential_refit: False
+hospital_parameters:
+  hospital_stay_death: 6
+  hospital_stay_recover: 14
+  hospital_stay_recover_icu: 20
+  hospital_to_icu: 3
+  icu_stay_recover: 13
+  icu_ratio: 0.25
+  intubation_ratio: 0.85
+  correction_factor_smooth_window: 14
+  hospital_correction_factor_min: 0.5
+  hospital_correction_factor_max: 25
+  icu_correction_factor_min: 0.05
+  icu_correction_factor_max: 0.95
+  intubation_correction_factor_min: 0.35
+  intubation_correction_factor_max: 1.0
+  correction_factor_average_window: 42
+  correction_factor_application_window: 42
 covariates:
   intercept:
     # Ordering of covariates in regression.  Covariates with the same order

--- a/specification_templates/regression.yaml
+++ b/specification_templates/regression.yaml
@@ -1,15 +1,21 @@
 data:
   infection_version: '2021_01_06.01'
   covariate_version: '2021_01_07.04'
+  mortality_rate_version: 'best'
+  hospital_fatality_ratio_version: 'best'
   coefficient_version: ''
   location_set_version_id: ''
-  location_set_file: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/location_metadata_771.csv'
+  location_set_file: '/ihme/covid-19/seir-pipeline-outputs/metadata-inputs/location_metadata_810.csv'
   output_root: ''
 workflow:
   project: 'proj_covid'
   queue: 'all.q'
   tasks:
     beta_regression:
+      max_runtime_seconds: 3000
+      m_mem_free: '2G'
+      num_cores: 1
+    hospital_correction_factors:
       max_runtime_seconds: 3000
       m_mem_free: '2G'
       num_cores: 1
@@ -22,6 +28,23 @@ regression_parameters:
   gamma2: [0.3333, 1.0]
   solver_dt: 0.1
   sequential_refit: False
+hospital_parameters:
+  hospital_stay_death: 6
+  hospital_stay_recover: 14
+  hospital_stay_recover_icu: 20
+  hospital_to_icu: 3
+  icu_stay_recover: 13
+  icu_ratio: 0.25
+  intubation_ratio: 0.85
+  correction_factor_smooth_window: 14
+  hospital_correction_factor_min: 0.5
+  hospital_correction_factor_max: 25
+  icu_correction_factor_min: 0.05
+  icu_correction_factor_max: 0.95
+  intubation_correction_factor_min: 0.35
+  intubation_correction_factor_max: 1.0
+  correction_factor_average_window: 42
+  correction_factor_application_window: 42
 covariates:
   intercept:
     # Ordering of covariates in regression.  Covariates with the same order

--- a/specification_templates/regression.yaml
+++ b/specification_templates/regression.yaml
@@ -1,6 +1,6 @@
 data:
-  infection_version: '2021_01_06.01'
-  covariate_version: '2021_01_07.04'
+  infection_version: '2021_01_13.02'
+  covariate_version: '2021_01_12.04'
   mortality_rate_version: 'best'
   hospital_fatality_ratio_version: 'best'
   coefficient_version: ''

--- a/src/covid_model_seiir_pipeline/cli.py
+++ b/src/covid_model_seiir_pipeline/cli.py
@@ -34,6 +34,8 @@ def seiir():
 @cli_tools.with_regression_specification
 @cli_tools.with_infection_version
 @cli_tools.with_covariates_version
+@cli_tools.with_mortality_rate_version
+@cli_tools.with_hospital_fatality_ratio_version
 @cli_tools.with_coefficient_version
 @cli_tools.with_location_specification
 @cli_tools.add_preprocess_only
@@ -41,7 +43,9 @@ def seiir():
 @cli_tools.add_verbose_and_with_debugger
 def regress(run_metadata,
             regression_specification,
-            infection_version, covariates_version, coefficient_version,
+            infection_version, covariates_version,
+            mortality_rate_version, hospital_fatality_ratio_version,
+            coefficient_version,
             location_specification,
             preprocess_only,
             output_root, mark_best, production_tag,
@@ -54,6 +58,8 @@ def regress(run_metadata,
         regression_specification=regression_specification,
         infection_version=infection_version,
         covariates_version=covariates_version,
+        mortality_rate_version=mortality_rate_version,
+        hospital_fatality_ratio_version=hospital_fatality_ratio_version,
         coefficient_version=coefficient_version,
         location_specification=location_specification,
         preprocess_only=preprocess_only,
@@ -193,6 +199,8 @@ def run_all(run_metadata,
         regression_specification=regression_specification,
         infection_version=None,
         covariates_version=None,
+        mortality_rate_version=None,
+        hospital_fatality_ratio_version=None,
         coefficient_version=None,
         location_specification=None,
         preprocess_only=False,
@@ -312,6 +320,8 @@ def _do_regression(run_metadata: cli_tools.RunMetadata,
                    regression_specification: str,
                    infection_version: Optional[str],
                    covariates_version: Optional[str],
+                   mortality_rate_version: Optional[str],
+                   hospital_fatality_ratio_version: Optional[str],
                    coefficient_version: Optional[str],
                    location_specification: Optional[str],
                    preprocess_only: bool,
@@ -332,6 +342,20 @@ def _do_regression(run_metadata: cli_tools.RunMetadata,
             regression_spec.data.covariate_version,
             paths.SEIR_COVARIATES_OUTPUT_ROOT,
             'covariates_metadata',
+            True,
+        ),
+        'mortality_rate_version': cli_tools.VersionInfo(
+            mortality_rate_version,
+            regression_spec.data.mortality_rate_version,
+            paths.MORTALITY_RATIO_ROOT,
+            'mortality_rate_metadata',
+            True,
+        ),
+        'hospital_fatality_ratio_version': cli_tools.VersionInfo(
+            hospital_fatality_ratio_version,
+            regression_spec.data.hospital_fatality_ratio_version,
+            paths.HOSPITAL_DEATH_RATIO_ROOT,
+            'hospital_fatality_ratio_metadata',
             True,
         ),
         'coefficient_version': cli_tools.VersionInfo(

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/__init__.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/__init__.py
@@ -21,6 +21,8 @@ from covid_model_seiir_pipeline.lib.cli_tools.decorators import (
     with_predictive_validity_specification,
     with_infection_version,
     with_covariates_version,
+    with_mortality_rate_version,
+    with_hospital_fatality_ratio_version,
     with_coefficient_version,
     with_location_specification,
     with_regression_version,

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/decorators.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/decorators.py
@@ -42,12 +42,12 @@ with_covariates_version = click.option(
 )
 with_mortality_rate_version = click.option(
     '--mortality-rate-version',
-    path=click.Path(exists=True, file_okay=False),
+    type=click.Path(exists=True, file_okay=False),
     help='Which version of the mortality age pattern to use.',
 )
 with_hospital_fatality_ratio_version = click.option(
     '--hospital-fatality-ratio-version',
-    path=click.Path(exists=True, file_okay=False),
+    type=click.Path(exists=True, file_okay=False),
     help='Which version of the hospital fatality ratio to use.'
 )
 with_coefficient_version = click.option(

--- a/src/covid_model_seiir_pipeline/lib/cli_tools/decorators.py
+++ b/src/covid_model_seiir_pipeline/lib/cli_tools/decorators.py
@@ -40,6 +40,16 @@ with_covariates_version = click.option(
     type=click.Path(exists=True, file_okay=False),
     help='Which version of covariates to use.',
 )
+with_mortality_rate_version = click.option(
+    '--mortality-rate-version',
+    path=click.Path(exists=True, file_okay=False),
+    help='Which version of the mortality age pattern to use.',
+)
+with_hospital_fatality_ratio_version = click.option(
+    '--hospital-fatality-ratio-version',
+    path=click.Path(exists=True, file_okay=False),
+    help='Which version of the hospital fatality ratio to use.'
+)
 with_coefficient_version = click.option(
     '--coefficient-version',
     type=click.Path(exists=True, file_okay=False),

--- a/src/covid_model_seiir_pipeline/lib/io/__init__.py
+++ b/src/covid_model_seiir_pipeline/lib/io/__init__.py
@@ -5,6 +5,8 @@ from covid_model_seiir_pipeline.lib.io.keys import (
 from covid_model_seiir_pipeline.lib.io.data_roots import (
     InfectionRoot,
     CovariateRoot,
+    MortalityRateRoot,
+    HospitalFatalityRatioRoot,
     RegressionRoot,
     ForecastRoot,
     PostprocessingRoot

--- a/src/covid_model_seiir_pipeline/lib/io/data_roots.py
+++ b/src/covid_model_seiir_pipeline/lib/io/data_roots.py
@@ -122,6 +122,20 @@ class InfectionRoot(DataRoot):
         )
 
 
+class MortalityRateRoot(DataRoot):
+    """Data root representing age pattern of mortality."""
+    metadata = MetadataType('metadata')
+
+    mortality_rate = DatasetType('mortality_ratio_5yr')
+
+
+class HospitalFatalityRatioRoot(DataRoot):
+    """Data root representing the hospital fatality ratio."""
+    metadata = MetadataType('metadata')
+
+    hospital_fatality_ratio = DatasetType('HR_byloc_blend_with_ids')
+
+
 class CovariateRoot(DataRoot):
     """Data root representing prepped covariates."""
     metadata = MetadataType('metadata')
@@ -167,6 +181,7 @@ class RegressionRoot(DataRoot):
     infection_data = DatasetType('data', LEAF_TEMPLATES.DRAW_TEMPLATE)
     dates = DatasetType('dates', LEAF_TEMPLATES.DRAW_TEMPLATE)
     parameters = DatasetType('parameters', LEAF_TEMPLATES.DRAW_TEMPLATE)
+    hospitalizations = DatasetType('hospitalization', LEAF_TEMPLATES.MEASURE_TEMPLATE)
 
 
 class ForecastRoot(DataRoot):

--- a/src/covid_model_seiir_pipeline/pipeline/regression/__init__.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/__init__.py
@@ -3,4 +3,7 @@ from covid_model_seiir_pipeline.pipeline.regression.specification import (
     RegressionSpecification,
 )
 from covid_model_seiir_pipeline.pipeline.regression.data import RegressionDataInterface
-from covid_model_seiir_pipeline.pipeline.regression.task import beta_regression
+from covid_model_seiir_pipeline.pipeline.regression.task import (
+    beta_regression,
+    hospital_correction_factors,
+)

--- a/src/covid_model_seiir_pipeline/pipeline/regression/model/__init__.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/model/__init__.py
@@ -8,3 +8,8 @@ from covid_model_seiir_pipeline.pipeline.regression.model.regress import (
     align_beta_with_covariates,
     build_regressor,
 )
+from covid_model_seiir_pipeline.pipeline.regression.model.hospital_corrections import (
+    get_death_weights,
+    compute_hospital_usage,
+    calculate_hospital_correction_factors,
+)

--- a/src/covid_model_seiir_pipeline/pipeline/regression/model/hospital_corrections.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/model/hospital_corrections.py
@@ -1,0 +1,366 @@
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from covid_model_seiir_pipeline.pipeline.regression.data import (
+        HospitalFatalityRatioData,
+        HospitalCorrectionsData,
+    )
+    from covid_model_seiir_pipeline.pipeline.regression.specification import (
+        HospitalParameters,
+    )
+
+
+# FIXME: These bins are a hangover from early covid CDC data.
+AGE_BINS = [0, 55, 65, 75, 85, 125]
+
+
+def get_death_weights(mr: pd.Series, population: pd.DataFrame, with_error: bool) -> pd.Series:
+    """Get a series of weights to split all age deaths into age-specific."""
+    pop = population.copy()
+    # Coerce population to series matching index of MR
+    pop['age_start'] = pop['age_group_years_start'].astype(int)
+    pop = pop.loc[:, ['location_id', 'age_start', 'population']].set_index(['location_id', 'age_start']).population
+
+    calc_func = {True: _get_death_weight_error, False: _get_death_weight_correct}[with_error]
+    return calc_func(mr, pop)
+
+
+def _get_death_weight_correct(mr: pd.Series, pop: pd.Series) -> pd.Series:
+    def _compute_death_weight(df, start, end):
+        return df.loc[(start <= df.age_start) & (df.age_start < end), 'mr_prob'].sum() / df['mr_prob'].sum()
+
+    mr_prob = (mr * pop).rename('mr_prob').reset_index()
+    death_weight_dfs = []
+    for age_start, age_end in zip(AGE_BINS, AGE_BINS[1:]):
+        age_death_weight = (mr_prob
+                            .groupby('location_id')
+                            .apply(lambda x: _compute_death_weight(x, age_start, age_end))
+                            .rename('death_weight')
+                            .reset_index())
+        age_death_weight['age'] = age_start + (age_end - age_start) / 2
+        death_weight_dfs.append(age_death_weight)
+    death_weights = pd.concat(death_weight_dfs)
+
+    return death_weights.set_index(['location_id', 'age']).sort_index().death_weight
+
+
+def _get_death_weight_error(mr: pd.Series, pop: pd.Series) -> pd.Series:
+    combined_mr_pop = pd.concat([mr, pop], axis=1)
+
+    def _compute_mr_prob_error(df, start, end):
+        df = df.reset_index()
+        this_bin_bad = df[(start <= df.age_start) & (df.age_start < end - 5)]
+        bad_weighted_mr = (this_bin_bad['MRprob'] * this_bin_bad['population'] / this_bin_bad['population'].sum()).sum()
+        this_actual_pop = df.loc[(age_start <= df.age_start) & (df.age_start < age_end), 'population'].sum()
+        return bad_weighted_mr * this_actual_pop
+
+    weighted_mr_dfs = []
+    for age_start, age_end in zip(AGE_BINS, AGE_BINS[1:]):
+        mr_weight = (combined_mr_pop
+                     .groupby('location_id')
+                     .apply(lambda x: _compute_mr_prob_error(x, age_start, age_end))
+                     .rename('bad_weighted_mr')
+                     .reset_index())
+        mr_weight['age'] = age_start + (age_end - age_start) / 2
+        weighted_mr_dfs.append(mr_weight)
+    bad_weighted_mr = pd.concat(weighted_mr_dfs).set_index(['location_id', 'age']).sort_index().bad_weighted_mr
+    bad_death_weights = (bad_weighted_mr / bad_weighted_mr.groupby('location_id').sum()).rename('death_weight')
+    return bad_death_weights
+
+
+def _bound(low, high, value):
+    """Helper to fix out of bounds probabilities.
+    As written, we can have a negative probability of being in the icu and
+    a > 1 probability of being intubated.
+    """
+    return np.maximum(low, np.minimum(high, value))
+
+
+def get_p_icu_if_recover(hr_all_age: pd.Series, hospital_parameters: 'HospitalParameters'):
+    """Get probability of going to ICU given the patient recovered
+    This fixes the long term average of [# used ICU beds]/[# hospitalized]
+    to be expected ICU ratio.
+    """
+    # noinspection PyTypeChecker
+    prob_death = 1 / hr_all_age
+    prob_recover = 1 - prob_death
+
+    icu_ratio = hospital_parameters.icu_ratio
+    days_to_death_prob = hospital_parameters.hospital_stay_death + 1
+    days_in_hosp_no_icu_prob = hospital_parameters.hospital_stay_recover + 1
+    days_in_hosp_icu_prob = hospital_parameters.hospital_stay_recover_icu + 1
+    days_in_icu_recover_prob = hospital_parameters.icu_stay_recover + 1
+
+    # Fixme: For some reason, this can be negative.
+    prob_icu_if_recover = (
+            (icu_ratio * (days_to_death_prob * prob_death + days_in_hosp_no_icu_prob * prob_recover)
+             - days_to_death_prob * prob_death)
+            / ((icu_ratio * (days_in_hosp_no_icu_prob - days_in_hosp_icu_prob)
+                + days_in_icu_recover_prob) * prob_recover)
+    )
+
+    return _bound(0, 1, prob_icu_if_recover)
+
+
+def get_p_int_if_icu_and_recover(hr_all_age: pd.Series, hospital_parameters: 'HospitalParameters'):
+    """Get the probability of intubation among recovered ICU patients.
+    This fixes the long term average of [# intubated]/[# in icu] to be
+    the expected intubation ratio.
+    """
+    # noinspection PyTypeChecker
+    prob_death = 1 / hr_all_age
+    prob_recover = 1 - prob_death
+
+    prob_icu = get_p_icu_if_recover(hr_all_age, hospital_parameters)
+
+    int_ratio = hospital_parameters.intubation_ratio
+    days_to_death_prob = hospital_parameters.hospital_stay_death + 1
+    days_in_hosp_icu_prob = hospital_parameters.hospital_stay_recover_icu + 1
+
+    # Fixme: For some reason, this can be negative. This doesn't really make
+    #    sense, but it's how the R code works.
+    prob_int = (
+            (int_ratio * (days_to_death_prob * prob_death + days_in_hosp_icu_prob * prob_icu * prob_recover)
+             - days_to_death_prob * prob_death)
+            / (days_in_hosp_icu_prob * prob_icu * prob_recover)
+    )
+    # If the probability of icu is 0, the probability of being intubated
+    # condtional on ICU admission doesnt matter.
+    prob_int[prob_icu == 0] = 1
+
+    return _bound(0, 1, prob_int)
+
+
+def read_correction_data(correction_path):
+    df = pd.read_csv(correction_path)
+    df = df.loc[(df.age_group_id == 22) & (df.sex_id == 3), ['location_id', 'date', 'value']]
+    return df
+
+
+def _to_census(admissions: pd.Series, length_of_stay: int) -> pd.Series:
+    return (admissions
+            .groupby('location_id')
+            .transform(lambda x: x.rolling(length_of_stay).sum())
+            .fillna(0))
+
+
+def compute_hospital_usage(all_age_deaths: pd.DataFrame,
+                           death_weights: pd.Series,
+                           hospital_fatality_ratio: 'HospitalFatalityRatioData',
+                           hospital_parameters: 'HospitalParameters') -> 'HospitalMetrics':
+    all_age_deaths = all_age_deaths.set_index(['location_id', 'date'])['deaths'].sort_index()
+    age_specific_deaths = (all_age_deaths * death_weights).reorder_levels(['location_id', 'age', 'date'])
+
+    prob_icu = get_p_icu_if_recover(hospital_fatality_ratio.all_age, hospital_parameters)
+    prob_no_icu = 1 - prob_icu
+    prob_invasive = get_p_int_if_icu_and_recover(hospital_fatality_ratio.all_age, hospital_parameters)
+    # noinspection PyTypeChecker
+    # For each death, calculate number of hospital admissions of people who
+    # don't die and shift back in time.
+    recovered_hospital_admissions = (
+        (age_specific_deaths * (hospital_fatality_ratio.age_specific - 1))
+        .groupby(['location_id', 'date'])
+        .sum()
+        .groupby('location_id')
+        .shift(-(hospital_parameters.hospital_stay_death - 1), fill_value=0)
+    )
+    # Split people into those who go to ICU and those who don't and count the
+    # days they spend in the hospital.
+    recovered_hospital_census = (
+        _to_census(prob_no_icu * recovered_hospital_admissions, hospital_parameters.hospital_stay_recover)
+        + _to_census(prob_icu * recovered_hospital_admissions, hospital_parameters.hospital_stay_recover_icu)
+    )
+    # Scale down hospitalizations to those who go to ICU and shift forward.
+    recovered_icu_admissions = (
+        (prob_icu * recovered_hospital_admissions)
+        .groupby('location_id')
+        .shift(hospital_parameters.hospital_to_icu, fill_value=0)
+    )
+    # Count number of days those who go to ICU spend there.
+    recovered_icu_census = _to_census(recovered_icu_admissions, hospital_parameters.icu_stay_recover)
+    # Ventilation usage is just scaled ICU usage.
+    recovered_ventilator_census = prob_invasive * recovered_icu_census
+
+    # Every death corresponds to a hospital admission shifted back some number
+    # of days.
+    dead_hospital_admissions = (
+        all_age_deaths
+        .groupby('location_id')
+        .shift(-(hospital_parameters.hospital_stay_death - 1), fill_value=0)
+    )
+    # Count days from admission to get hospital census for those who die.
+    dead_hospital_census = _to_census(dead_hospital_admissions, hospital_parameters.hospital_stay_death)
+    # Assume people who die after entering the hospital are intubated in the
+    # ICU for their full stay.
+    dead_icu_admissions = dead_hospital_admissions.copy()
+    dead_icu_census = dead_hospital_census.copy()
+    dead_ventilator_census = dead_icu_census.copy()
+
+    def _combine(recovered, dead):
+        # Drop data after the last admission since it will be incomplete.
+        return (
+            (recovered + dead)
+            .groupby(['location_id'])
+            .apply(lambda x: x.iloc[:-(hospital_parameters.hospital_stay_death - 1)])
+            .reset_index(level=0, drop=True)
+        )
+
+    return HospitalMetrics(
+        hospital_admissions=_combine(recovered_hospital_admissions, dead_hospital_admissions),
+        hospital_census=_combine(recovered_hospital_census, dead_hospital_census),
+        icu_admissions=_combine(recovered_icu_admissions, dead_icu_admissions),
+        icu_census=_combine(recovered_icu_census, dead_icu_census),
+        ventilator_census=_combine(recovered_ventilator_census, dead_ventilator_census),
+    )
+
+
+def _compute_correction_factor(raw_log_cf: pd.Series,
+                               min_date: pd.Timestamp,
+                               max_date: pd.Timestamp,
+                               smoothing_window: int) -> pd.Series:
+    date_index = pd.date_range(min_date, max_date).rename('date')
+
+    data_locs = raw_log_cf.reset_index().location_id.unique().tolist()
+    log_cf = []
+    for location_id in data_locs:
+        raw_log_cf_loc = raw_log_cf.loc[location_id].reset_index()
+        raw_log_cf_loc['int_date'] = raw_log_cf_loc['date'].astype(int)
+        # This log space mean is a geometric mean in natural units.
+        log_cf_loc = raw_log_cf_loc[['int_date', 'log_cf']].rolling(smoothing_window).mean().dropna()
+        log_cf_loc['date'] = pd.to_datetime(log_cf_loc['int_date'])
+        # Interpolate our moving average to fill gaps.
+        log_cf_loc = log_cf_loc.set_index('date').reindex(date_index, method='nearest')
+        log_cf_loc['location_id'] = location_id
+        log_cf_loc = log_cf_loc.reset_index().set_index(['location_id', 'date']).log_cf
+        log_cf.append(log_cf_loc)
+    log_cf = pd.concat(log_cf)
+
+    return log_cf
+
+
+def _fill_missing_locations(log_cf: pd.Series, aggregation_hierarchy: pd.DataFrame) -> pd.Series:
+    data_locs = log_cf.reset_index().location_id.unique().tolist()
+    # Aggregate up the hierarchy using as many of the children as we can.
+    # First build a map between locations and all their children.
+    all_children_map = defaultdict(list)
+    path_to_top_map = aggregation_hierarchy.set_index('location_id').path_to_top_parent.to_dict()
+    for child_id, path_to_top_parent in path_to_top_map.items():
+        for parent_id in path_to_top_parent.split(','):
+            parent_id = int(parent_id)
+            if parent_id != child_id:
+                all_children_map[parent_id].append(child_id)
+
+    # Take the mean in log space (geometric mean in normal space) by date of all children.
+    parent_ids = aggregation_hierarchy[aggregation_hierarchy.most_detailed == 0].location_id.unique()
+    for parent_id in parent_ids:
+        children = all_children_map[parent_id]
+        modeled_children = set(data_locs).intersection(children)
+        if modeled_children:
+            parent_log_cf = log_cf.loc[modeled_children].groupby(level='date').mean().reset_index()
+            parent_log_cf['location_id'] = parent_id
+            parent_log_cf = parent_log_cf.set_index(['location_id', 'date']).log_cf
+            log_cf = log_cf.append(parent_log_cf)
+            data_locs.append(parent_id)
+
+    # Fill back in with the nearest parent
+    levels = sorted(aggregation_hierarchy.level.unique().tolist())
+    for level in levels[:-1]:
+        parents_at_level = aggregation_hierarchy[aggregation_hierarchy.level == level].location_id.unique()
+        for parent_id in parents_at_level:
+            assert parent_id in data_locs
+            children = aggregation_hierarchy[aggregation_hierarchy.parent_id == parent_id].location_id.unique()
+            for child_id in children:
+                if child_id not in data_locs:
+                    child_log_cf = log_cf.loc[parent_id].reset_index()
+                    child_log_cf['location_id'] = child_id
+                    child_log_cf = child_log_cf.set_index(['location_id', 'date']).log_cf
+                    log_cf = log_cf.append(child_log_cf)
+                    data_locs.append(child_id)
+
+    assert not set(data_locs).difference(aggregation_hierarchy.location_id)
+
+    return log_cf
+
+
+def _safe_log_divide(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
+    """We need to do a bunch of geometric means of ratios. This is just the
+    average log difference.  This mean is poorly behaved for numbers between
+    0 and 1 and so we add 1 to the numerator and denominator. This is
+    approximately correct in all situations we care about and radically
+    improves the behavior for small numbers."""
+    # noinspection PyTypeChecker
+    return (np.log(numerator + 1) - np.log(denominator + 1)).dropna().rename('log_cf')
+
+
+def calculate_hospital_correction_factors(usage: 'HospitalMetrics',
+                                          correction_data: 'HospitalCorrectionsData',
+                                          aggregation_hierarchy: pd.DataFrame,
+                                          hospital_parameters: 'HospitalParameters') -> 'HospitalCorrectionFactors':
+    date = usage.hospital_census.reset_index().date
+    min_date, max_date = date.min(), date.max()
+
+    raw_log_hospital_cf = _safe_log_divide(correction_data.hospital_census, usage.hospital_census)
+
+    log_hospital_cf = _compute_correction_factor(
+        raw_log_hospital_cf,
+        min_date, max_date,
+        hospital_parameters.correction_factor_smooth_window,
+    )
+    hospital_cf = np.exp(_fill_missing_locations(log_hospital_cf, aggregation_hierarchy))
+    hospital_cf = hospital_cf.clip(lower=hospital_parameters.hospital_correction_factor_min,
+                                   upper=hospital_parameters.hospital_correction_factor_max)
+
+    modeled_icu_log_ratio = _safe_log_divide(usage.icu_census, usage.hospital_census)
+    historical_icu_log_ratio = _safe_log_divide(correction_data.icu_census, correction_data.hospital_census)
+    raw_log_icu_ratio_cf = (historical_icu_log_ratio - modeled_icu_log_ratio).dropna()
+
+    log_icu_ratio_cf = _compute_correction_factor(
+        raw_log_icu_ratio_cf,
+        min_date, max_date,
+        hospital_parameters.correction_factor_smooth_window,
+    )
+    log_icu_cf = (modeled_icu_log_ratio + log_icu_ratio_cf).dropna()
+    icu_cf = np.exp(_fill_missing_locations(log_icu_cf, aggregation_hierarchy))
+    icu_cf = icu_cf.clip(lower=hospital_parameters.icu_correction_factor_min,
+                         upper=hospital_parameters.icu_correction_factor_max)
+
+    modeled_ventilator_log_ratio = _safe_log_divide(usage.ventilator_census, usage.icu_census)
+    historical_ventilator_log_ratio = _safe_log_divide(correction_data.ventilator_census, correction_data.icu_census)
+    raw_log_ventilator_ratio_cf = (historical_ventilator_log_ratio - modeled_ventilator_log_ratio).dropna()
+
+    log_ventilator_ratio_cf = _compute_correction_factor(
+        raw_log_ventilator_ratio_cf,
+        min_date, max_date,
+        hospital_parameters.correction_factor_smooth_window,
+    )
+    log_ventilator_cf = (modeled_ventilator_log_ratio + log_ventilator_ratio_cf).dropna()
+    ventilator_cf = np.exp(_fill_missing_locations(log_ventilator_cf, aggregation_hierarchy))
+    ventilator_cf = ventilator_cf.clip(lower=hospital_parameters.intubation_correction_factor_min,
+                                       upper=hospital_parameters.intubation_correction_factor_max)
+
+    return HospitalCorrectionFactors(
+        hospital_census=hospital_cf,
+        icu_census=icu_cf,
+        ventilator_census=ventilator_cf,
+    )
+
+
+@dataclass
+class HospitalMetrics:
+    hospital_admissions: pd.Series
+    hospital_census: pd.Series
+    icu_admissions: pd.Series
+    icu_census: pd.Series
+    ventilator_census: pd.Series
+
+
+@dataclass
+class HospitalCorrectionFactors:
+    hospital_census: pd.Series
+    icu_census: pd.Series
+    ventilator_census: pd.Series

--- a/src/covid_model_seiir_pipeline/pipeline/regression/specification.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/specification.py
@@ -9,6 +9,7 @@ from covid_model_seiir_pipeline.lib import (
 
 class __RegressionJobs(NamedTuple):
     regression: str = 'beta_regression'
+    hospital_correction_factors: str = 'hospital_correction_factors'
 
 
 REGRESSION_JOBS = __RegressionJobs()
@@ -21,10 +22,18 @@ class RegressionTaskSpecification(workflow.TaskSpecification):
     default_num_cores = 1
 
 
+class HospitalCorrectionFactorTaskSpecification(workflow.TaskSpecification):
+    """Specification of execution parameters for regression tasks."""
+    default_max_runtime_seconds = 3000
+    default_m_mem_free = '2G'
+    default_num_cores = 1
+
+
 class RegressionWorkflowSpecification(workflow.WorkflowSpecification):
     """Specification of execution parameters for regression workflows."""
     tasks = {
         REGRESSION_JOBS.regression: RegressionTaskSpecification,
+        REGRESSION_JOBS.hospital_correction_factors: HospitalCorrectionFactorTaskSpecification,
     }
 
 
@@ -33,6 +42,8 @@ class RegressionData:
     """Specifies the inputs and outputs for a regression"""
     covariate_version: str = field(default='best')
     infection_version: str = field(default='best')
+    mortality_rate_version: str = field(default='best')
+    hospital_fatality_ratio_version: str = field(default='best')
     coefficient_version: str = field(default='')
     location_set_version_id: int = field(default=0)
     location_set_file: str = field(default='')
@@ -56,6 +67,31 @@ class RegressionParameters:
     gamma2: Tuple[float, float] = field(default=(1/3, 1.0))
     solver_dt: float = field(default=0.1)
     sequential_refit: bool = field(default=False)
+
+    def to_dict(self) -> Dict:
+        """Converts to a dict, coercing list-like items to lists."""
+        return utilities.asdict(self)
+
+
+@dataclass
+class HospitalParameters:
+    """Parameters for the hospital model calculation."""
+    hospital_stay_death: int = field(default=6)
+    hospital_stay_recover: int = field(default=14)
+    hospital_stay_recover_icu: int = field(default=20)
+    hospital_to_icu: int = field(default=3)
+    icu_stay_recover: int = field(default=13)
+    icu_ratio: float = field(default=0.25)
+    intubation_ratio: float = field(default=0.85)
+    correction_factor_smooth_window: int = field(default=14)
+    hospital_correction_factor_min: float = field(default=0.5)
+    hospital_correction_factor_max: float = field(default=25.0)
+    icu_correction_factor_min: float = field(default=0.05)
+    icu_correction_factor_max: float = field(default=0.95)
+    intubation_correction_factor_min: float = field(default=0.35)
+    intubation_correction_factor_max: float = field(default=1.0)
+    correction_factor_average_window: int = field(default=42)
+    correction_factor_application_window: int = field(default=42)
 
     def to_dict(self) -> Dict:
         """Converts to a dict, coercing list-like items to lists."""
@@ -91,10 +127,12 @@ class RegressionSpecification(utilities.Specification):
                  data: RegressionData,
                  workflow: RegressionWorkflowSpecification,
                  regression_parameters: RegressionParameters,
+                 hospital_parameters: HospitalParameters,
                  covariates: List[CovariateSpecification]):
         self._data = data
         self._workflow = workflow
         self._regression_parameters = regression_parameters
+        self._hospital_parameters = hospital_parameters
         self._covariates = {c.name: c for c in covariates}
 
     @classmethod
@@ -104,6 +142,7 @@ class RegressionSpecification(utilities.Specification):
             'data': RegressionData,
             'workflow': RegressionWorkflowSpecification,
             'regression_parameters': RegressionParameters,
+            'hospital_parameters': HospitalParameters,
         }
         sub_specs = {key: spec_class(**regression_spec_dict.get(key, {})) for key, spec_class in sub_specs.items()}
 
@@ -134,6 +173,11 @@ class RegressionSpecification(utilities.Specification):
         return self._regression_parameters
 
     @property
+    def hospital_parameters(self) -> HospitalParameters:
+        """The parameterization of the hospital algorithm"""
+        return self._hospital_parameters
+
+    @property
     def covariates(self) -> Dict[str, CovariateSpecification]:
         """The covariates for the regression."""
         return self._covariates
@@ -144,6 +188,7 @@ class RegressionSpecification(utilities.Specification):
             'data': self.data.to_dict(),
             'workflow': self.workflow.to_dict(),
             'regression_parameters': self.regression_parameters.to_dict(),
+            'hospital_parameters': self.hospital_parameters.to_dict(),
             'covariates': {k: v.to_dict() for k, v in self._covariates.items()},
         }
         return spec

--- a/src/covid_model_seiir_pipeline/pipeline/regression/task/__init__.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/task/__init__.py
@@ -1,3 +1,6 @@
 from covid_model_seiir_pipeline.pipeline.regression.task.beta_regression import (
     beta_regression,
 )
+from covid_model_seiir_pipeline.pipeline.regression.task.hospital_correction_factors import (
+    hospital_correction_factors,
+)

--- a/src/covid_model_seiir_pipeline/pipeline/regression/task/hospital_correction_factors.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/task/hospital_correction_factors.py
@@ -1,0 +1,93 @@
+from dataclasses import asdict
+from pathlib import Path
+
+import click
+import pandas as pd
+
+from covid_model_seiir_pipeline.lib import (
+    cli_tools,
+    static_vars,
+    math,
+)
+from covid_model_seiir_pipeline.pipeline.regression.specification import (
+    RegressionSpecification,
+)
+from covid_model_seiir_pipeline.pipeline.regression.data import (
+    RegressionDataInterface,
+)
+from covid_model_seiir_pipeline.pipeline.regression import (
+    model,
+)
+
+
+logger = cli_tools.task_performance_logger
+
+
+def run_hospital_correction_factors(regression_version: str, with_error: bool) -> None:
+    logger.info('Starting hospital correction factors.', context='setup')
+    # Build helper abstractions
+    regression_spec_file = Path(regression_version) / static_vars.REGRESSION_SPECIFICATION_FILE
+    regression_specification = RegressionSpecification.from_path(regression_spec_file)
+    hospital_parameters = regression_specification.hospital_parameters
+    data_interface = RegressionDataInterface.from_specification(regression_specification)
+
+    logger.info('Loading input data', context='read')
+    hierarchy = data_interface.load_hierarchy()
+    location_ids = data_interface.load_location_ids()
+    # We just want the mean deaths through here, which is the same across
+    # all draws, so we'll default to draw 0.
+    infectionator_data = data_interface.load_all_location_data(
+        location_ids=location_ids,
+        draw_id=0,
+    )
+    infectionator_data = pd.concat(infectionator_data.values())
+    infectionator_data['date'] = pd.to_datetime(infectionator_data['date'])
+    _, deaths = math.get_observed_infecs_and_deaths(infectionator_data)
+    deaths = deaths.reset_index()
+
+    population = data_interface.load_five_year_population(location_ids)
+    mr = data_interface.load_mortality_ratio(location_ids)
+    death_weights = model.get_death_weights(mr, population, with_error)
+    hfr = data_interface.load_hospital_fatality_ratio(death_weights, location_ids, with_error)
+    hospital_correction_data = data_interface.load_hospital_correction_data()
+
+    logger.info('Computing hospital usage', context='compute_usage')
+    hospital_usage = model.compute_hospital_usage(
+        deaths,
+        death_weights,
+        hfr,
+        hospital_parameters,
+    )
+    logger.info('Computing correction factors', context='compute_corrections')
+    correction_factors = model.calculate_hospital_correction_factors(
+        hospital_usage,
+        hospital_correction_data,
+        hierarchy,
+        hospital_parameters,
+    )
+
+    logger.info('Prepping outputs', context='transform')
+    usage_df = pd.concat([value.rename(key) for key, value in asdict(hospital_usage).items()], axis=1).reset_index()
+    corrections_df = pd.concat([value.rename(key) for key, value in asdict(correction_factors).items()], axis=1).reset_index()
+
+    logger.info('Writing outputs', context='write')
+    data_interface.save_hospital_data(usage_df, 'usage')
+    data_interface.save_hospital_data(corrections_df, 'correction_factors')
+
+    logger.report()
+
+
+@click.command()
+@cli_tools.with_regression_version
+@click.option('-e', 'with_error', is_flag=True)
+@cli_tools.add_verbose_and_with_debugger
+def hospital_correction_factors(regression_version: str,
+                                with_error: bool, verbose: int, with_debugger: bool):
+    cli_tools.configure_logging_to_terminal(verbose)
+
+    run = cli_tools.handle_exceptions(run_hospital_correction_factors, logger, with_debugger)
+    run(regression_version=regression_version, with_error=with_error)
+
+
+if __name__ == '__main__':
+    hospital_correction_factors()

--- a/src/covid_model_seiir_pipeline/pipeline/regression/workflow.py
+++ b/src/covid_model_seiir_pipeline/pipeline/regression/workflow.py
@@ -17,18 +17,38 @@ class BetaRegressionTaskTemplate(workflow.TaskTemplate):
     task_args = ['regression_version']
 
 
+class HospitalCorrectionFactorTaskTemplate(workflow.TaskTemplate):
+    task_name_template = f"{REGRESSION_JOBS.hospital_correction_factors}"
+    command_template = (
+            f"{shutil.which('stask')} "
+            f"{REGRESSION_JOBS.hospital_correction_factors} "
+            "--regression-version {regression_version} " 
+            "-vv"
+    )
+    node_args = []
+    task_args = ['regression_version']
+
+
 class RegressionWorkflow(workflow.WorkflowTemplate):
 
     workflow_name_template = 'seiir-regression-{version}'
     task_template_classes = {
-        REGRESSION_JOBS.regression: BetaRegressionTaskTemplate
+        REGRESSION_JOBS.regression: BetaRegressionTaskTemplate,
+        REGRESSION_JOBS.hospital_correction_factors: HospitalCorrectionFactorTaskTemplate,
     }
 
     def attach_tasks(self, n_draws: int):
         regression_template = self.task_templates[REGRESSION_JOBS.regression]
+        hospital_correction_factor_template = self.task_templates[REGRESSION_JOBS.hospital_correction_factors]
+
         for draw_id in range(n_draws):
             task = regression_template.get_task(
                 regression_version=self.version,
                 draw_id=draw_id
             )
             self.workflow.add_task(task)
+
+        hospital_correction_task = hospital_correction_factor_template.get_task(
+                regression_version=self.version,
+            )
+        self.workflow.add_task(hospital_correction_task)

--- a/src/covid_model_seiir_pipeline/pipeline/seiir_task.py
+++ b/src/covid_model_seiir_pipeline/pipeline/seiir_task.py
@@ -3,6 +3,7 @@ import click
 from covid_model_seiir_pipeline.pipeline.regression import (
     REGRESSION_JOBS,
     beta_regression,
+    hospital_correction_factors,
 )
 from covid_model_seiir_pipeline.pipeline.forecasting import (
     FORECAST_JOBS,
@@ -27,6 +28,7 @@ def stask():
 
 
 stask.add_command(beta_regression, name=REGRESSION_JOBS.regression)
+stask.add_command(hospital_correction_factors, name=REGRESSION_JOBS.hospital_correction_factors)
 stask.add_command(beta_residual_scaling, name=FORECAST_JOBS.scaling)
 stask.add_command(beta_forecast, name=FORECAST_JOBS.forecast)
 stask.add_command(resample_map, name=POSTPROCESSING_JOBS.resample)

--- a/tests/forecasting/test_data.py
+++ b/tests/forecasting/test_data.py
@@ -21,6 +21,8 @@ class TestForecastDataInterfaceIO:
         rdi = RegressionDataInterface(
             infection_root=None,
             covariate_root=None,
+            mortality_rate_root=None,
+            hospital_fatality_ratio_root=None,
             coefficient_root=None,
             regression_root=io.RegressionRoot(tmpdir),
         )

--- a/tests/regression/test_data.py
+++ b/tests/regression/test_data.py
@@ -14,6 +14,8 @@ class TestRegressionDataInterfaceIO:
         di = RegressionDataInterface(
             infection_root=None,
             covariate_root=None,
+            mortality_rate_root=None,
+            hospital_fatality_ratio_root=None,
             coefficient_root=None,
             regression_root=io.RegressionRoot(tmpdir),
         )


### PR DESCRIPTION
This PR adds a new pipeline task that computes correction factors for the hospital census data based on deaths in the past.

The algorithm is roughly:
- Convert deaths to hospital admissions via the hospital fatality ratio
- Convert hospital admissions to icu admisssions via a lag and assumptions about icu admissions among those who live and die.
- Convert hospital admissions and icu admissions into census data via assumptions about duration of stay
- Compute correction factors by location based on ratios between observed hospital/icu/ventilator census and modeled.

There's a lot of cruft about wiring in a new task that is not vital for review. Likewise there's some data handling bits that are cribbed with pretty careful integration testing from the existing hospital model.  

I've taken a different approach to the core algorithmic pieces, however.  The original was working with a lot of geometric means and I swapped to working in log space for most of this where there are no divisions and the means are just normal arithmetic means.  

Fun note: this whole thing runs in about 30s on a single cpu with 2G of memory.  We have come a long way from our azure deployment days.