### PR TITLE
Collijk/bugfix/initial condition level

### DIFF
--- a/src/covid_model_seiir_pipeline/pipeline/fit/model/epi_measures.py
+++ b/src/covid_model_seiir_pipeline/pipeline/fit/model/epi_measures.py
@@ -25,7 +25,7 @@ def format_epi_measures(epi_measures: pd.DataFrame,
     global_date_range = pd.date_range(dates.min() - pd.Timedelta(days=max_duration), dates.max())
     square_idx = pd.MultiIndex.from_product((locations, global_date_range),
                                             names=['location_id', 'date']).sort_values()
-    epi_measures = epi_measures.reindex(square_idx).sort_index()
+    epi_measures = epi_measures.set_index(['location_id', 'date']).reindex(square_idx).sort_index()
 
     return epi_measures
 

--- a/src/covid_model_seiir_pipeline/pipeline/fit/model/ode_fit.py
+++ b/src/covid_model_seiir_pipeline/pipeline/fit/model/ode_fit.py
@@ -137,7 +137,7 @@ def reindex_to_infection_day(data: pd.DataFrame, lag: int, most_detailed: List[i
 def make_initial_condition(parameters: Parameters, full_rates: pd.DataFrame, population: pd.DataFrame):
     base_params = parameters.base_parameters
     
-    crude_infections = get_crude_infections(base_params, full_rates, population, threshold=50)    
+    crude_infections = get_crude_infections(base_params, full_rates, threshold=50)
     new_e_start = crude_infections.reset_index(level='date').groupby('location_id').first()
     start_date, new_e_start = new_e_start['date'], new_e_start['infections']
     end_date = base_params.filter(like='count')
@@ -180,7 +180,7 @@ def make_initial_condition(parameters: Parameters, full_rates: pd.DataFrame, pop
     return initial_condition
 
 
-def get_crude_infections(base_params, rates, population, threshold=50):
+def get_crude_infections(base_params, rates, threshold=50):
     crude_infections = pd.DataFrame(index=rates.index)
     for measure, rate in [('death', 'ifr'), ('admission', 'ihr'), ('case', 'idr')]:
         infections = base_params[f'count_all_{measure}'] / rates[rate]

--- a/src/covid_model_seiir_pipeline/pipeline/fit/model/ode_fit.py
+++ b/src/covid_model_seiir_pipeline/pipeline/fit/model/ode_fit.py
@@ -118,17 +118,9 @@ def prepare_epi_measures_and_rates(rates: Rates, epi_measures: pd.DataFrame, hie
         out_measures.append(epi_data)
         out_rates.append(epi_rates)
 
-    out_measures = pd.concat(out_measures, axis=1)
-    out_measures = out_measures.loc[out_measures.notnull().any(axis=1)]
-
-    dates = out_measures.reset_index().date
-    global_date_range = pd.date_range(dates.min() - pd.Timedelta(days=1), dates.max())
-    square_idx = pd.MultiIndex.from_product((most_detailed, global_date_range),
-                                            names=['location_id', 'date']).sort_values()
-
-    out_measures = out_measures.reindex(square_idx).sort_index()
-    out_rates = pd.concat(out_rates, axis=1).reindex(square_idx).sort_index()
-
+    out_measures = pd.concat(out_measures, axis=1).reset_index()
+    out_measures = out_measures.loc[out_measures.location_id.isin(most_detailed)].set_index(['location_id', 'date'])
+    out_rates = pd.concat(out_rates, axis=1).reindex(out_measures.index).sort_index()
     return out_measures, out_rates
 
 

--- a/src/covid_model_seiir_pipeline/pipeline/fit/model/plotter.py
+++ b/src/covid_model_seiir_pipeline/pipeline/fit/model/plotter.py
@@ -200,16 +200,16 @@ def ies_plot(data: Tuple[Location, Dict[str, pd.DataFrame]],
     if sero_data is not None:
         ax_cumul.scatter(sero_data.loc[sero_data['is_outlier'] == 1].index,
                          sero_data.loc[sero_data['is_outlier'] == 1, 'reported_seroprevalence'] * 100,
-                         s=80, c='maroon', alpha=0.45, marker='x')
+                         s=80, c='maroon', alpha=0.45, marker='x', zorder=2)
         ax_cumul.scatter(sero_data.loc[sero_data['is_outlier'] == 0].index,
                          sero_data.loc[sero_data['is_outlier'] == 0, 'reported_seroprevalence'] * 100,
-                         s=80, c='darkturquoise', edgecolors='darkcyan', alpha=0.3, marker='s')
+                         s=80, c='darkturquoise', edgecolors='darkcyan', alpha=0.3, marker='s', zorder=2)
         ax_cumul.scatter(sero_data.loc[sero_data['is_outlier'] == 0].index,
                          sero_data.loc[sero_data['is_outlier'] == 0, 'seroprevalence'] * 100,
-                         s=80, c='orange', edgecolors='darkorange', alpha=0.3, marker='^')
+                         s=80, c='orange', edgecolors='darkorange', alpha=0.3, marker='^', zorder=2)
         ax_cumul.scatter(sero_data.loc[sero_data['is_outlier'] == 0].index,
                          sero_data.loc[sero_data['is_outlier'] == 0, 'adjusted_seroprevalence'] * 100,
-                         s=100, c='mediumorchid', edgecolors='darkmagenta', alpha=0.6, marker='o')
+                         s=100, c='mediumorchid', edgecolors='darkmagenta', alpha=0.6, marker='o', zorder=2)
 
     group_axes = [ax_daily, ax_cumul]
 

--- a/src/covid_model_seiir_pipeline/pipeline/fit/model/sampled_params.py
+++ b/src/covid_model_seiir_pipeline/pipeline/fit/model/sampled_params.py
@@ -21,14 +21,16 @@ class Durations(NamedTuple):
     pcr_to_seropositive: int
     admission_to_seropositive: int
     seropositive_to_death: int
+    max_lag: int
 
 
 def sample_durations(params: RatesParameters, draw_id: int) -> Durations:
     random_state = utilities.get_random_state(f'epi_durations_draw_{draw_id}')
 
-    exposure_to_admission = random_state.choice(params.exposure_to_admission)
-    exposure_to_seroconversion = random_state.choice(params.exposure_to_seroconversion)
-    admission_to_death = random_state.choice(params.admission_to_death)
+    exposure_to_admission = random_state.choice(list(params.exposure_to_admission))
+    exposure_to_seroconversion = random_state.choice(list(params.exposure_to_seroconversion))
+    admission_to_death = random_state.choice(list(params.admission_to_death))
+    max_lag = max(list(params.exposure_to_admission)) + max(list(params.admission_to_death))
 
     return Durations(
         exposure_to_case=exposure_to_admission,
@@ -38,6 +40,7 @@ def sample_durations(params: RatesParameters, draw_id: int) -> Durations:
         pcr_to_seropositive=exposure_to_seroconversion - exposure_to_admission,
         admission_to_seropositive=exposure_to_seroconversion - exposure_to_admission,
         seropositive_to_death=(exposure_to_admission + admission_to_death) - exposure_to_seroconversion,
+        max_lag=max_lag,
     )
 
 

--- a/src/covid_model_seiir_pipeline/pipeline/fit/task/beta_fit.py
+++ b/src/covid_model_seiir_pipeline/pipeline/fit/task/beta_fit.py
@@ -62,13 +62,14 @@ def run_beta_fit(fit_version: str, draw_id: int, progress_bar: bool) -> None:
                .mean().rename(covariate))
         mr_covariates.append(cov)
 
-    logger.info('Rescaling deaths and formatting epi measures', context='transform')
-    epi_measures = model.format_epi_measures(epi_measures, mr_hierarchy, pred_hierarchy, mortality_scalar)
-
     logger.info('Sampling rates parameters', context='transform')
     durations = model.sample_durations(specification.rates_parameters, draw_id)
     variant_severity = model.sample_variant_severity(specification.rates_parameters, draw_id)
     day_inflection = model.sample_day_inflection(specification.rates_parameters, draw_id)
+
+    logger.info('Rescaling deaths and formatting epi measures', context='transform')
+    epi_measures = model.format_epi_measures(epi_measures, mr_hierarchy, pred_hierarchy, mortality_scalar, durations)
+
     logger.info('Subsetting seroprevalence for first pass rates model', context='transform')
     first_pass_seroprevalence = model.subset_seroprevalence(
         seroprevalence=seroprevalence,


### PR DESCRIPTION
This fixes the sharp increase in infections at the start of the ode.  When shifting the measures from index by report to index by date, I didn't have sufficient padding up front and so the series was being cut off.  This addresses the issue by starting with a square index that allows for the maximal possible shift.  This should also ensure concatenation of draws proceeds swiftly and make alignment in later stages easier.  

Also fixes the zorder for the sero data on the cumulative infections plot.